### PR TITLE
fix: declarative schema migration w drift detection and downgrade safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ const db = await Database.build<{
 }>('shop', [User, Order]);
 ```
 
-`Database.build` opens (or upgrades) the IDB database, creates object stores and indexes for any entity whose version exceeds the stored database version, starts background retention jobs if applicable, and attaches typed repository properties to the returned object.
+`Database.build` opens (or upgrades) the IDB database, reconciles the declared schema against the stored one (creating missing stores and indexes and removing indexes that are no longer declared), starts background retention jobs if applicable, and attaches typed repository properties to the returned object.
 
-The effective database version is the highest `version` value declared across all registered entities.
+The declared database version is the highest `version` value across all registered entities; see [Migration behaviour](#migration-behaviour) for how drift and downgrades are handled.
 
 ### Inspecting database metadata
 
@@ -542,7 +542,7 @@ When multiple entities define retention policies, the cleanup interval is set to
 
 ## Schema Versioning
 
-Increment an entity's `version` to trigger `onupgradeneeded` and update its object store on the user's next visit. The effective database version is the maximum across all registered entities, so adding a new high-version entity is sufficient to initiate a migration.
+Increment an entity's `version` to trigger `onupgradeneeded` and update its object store on the user's next visit. The declared database version is the maximum across all registered entities, so adding a new high-version entity is sufficient to initiate a migration.
 
 ```typescript
 @DataClass({ version: 1 })
@@ -558,13 +558,27 @@ class Comment {
   /* ... */
 }
 
-// Database opens at version 3.
-// If a user was on version 1, only Post (v2) and Comment (v3) stores are
-// created or updated during onupgradeneeded.
+// Database opens at version 3 and reconciles the full declared schema
+// (stores + indexes) inside the upgrade transaction.
 const db = await Database.build('blog', [User, Post, Comment]);
 
 console.log(db.getDatabaseVersion()); // 3
 ```
+
+### Migration behaviour
+
+Migration is **declarative**: on every upgrade the actual IndexedDB schema is reconciled against the schema declared by your decorators.
+
+| Change                                      | Handling                                                                                                                                                               |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New entity / store                          | Created automatically.                                                                                                                                                 |
+| Index added (even without a version bump)   | Detected as schema drift after opening; the database is reopened one version higher and the index is created. Existing records are re-indexed by IndexedDB.            |
+| Index removed (even without a version bump) | Detected as drift; the stale index is deleted. Record data is not affected.                                                                                            |
+| Entity `version` lowered                    | IndexedDB cannot downgrade. The database opens at the existing on-disk version instead of throwing `VersionError`; `getDatabaseVersion()` reports the on-disk version. |
+| Key path / `autoIncrement` changed          | **Not applied** — IndexedDB cannot change a store's key path in place. A warning is logged; migrate the data to a new entity or delete the database.                   |
+| Entity no longer registered                 | Its store and data are **preserved** and a warning is logged. Re-register the entity to access the data again, or delete the store manually.                           |
+
+> Because drift detection may reopen the database one version higher than declared, `getDatabaseVersion()` returns the _actual_ IndexedDB version, which can exceed the highest entity `version`.
 
 ---
 
@@ -589,92 +603,87 @@ Done in 383ms using pnpm v11.9.0
 
 ### Suite 1: CRUD Operations
 
-| Operation | Ops | Total ms | Ops/s | Avg ms | P50 | P95 | P99 | Min | Max |
-|-----------|-----:|---------:|------:|-------:|----:|----:|----:|----:|----:|
-| create (single) | 200 | 11.668 | 17,141.483 | 0.058 | 0.044 | 0.103 | 0.13 | 0.039 | 0.883 |
-| read (by PK) | 200 | 7.972 | 25,087.351 | 0.039 | 0.036 | 0.062 | 0.091 | 0.03 | 0.113 |
-| update (single) | 200 | 133.17 | 1,501.843 | 0.665 | 0.615 | 1.01 | 1.184 | 0.545 | 2.036 |
-| findByIndex (email) | 200 | 8.942 | 22,365.168 | 0.044 | 0.041 | 0.073 | 0.086 | 0.034 | 0.111 |
-| findOneByIndex (email) | 200 | 10.246 | 19,519.677 | 0.051 | 0.044 | 0.057 | 0.072 | 0.039 | 0.998 |
-| count | 200 | 8.28 | 24,155.266 | 0.041 | 0.04 | 0.049 | 0.055 | 0.037 | 0.079 |
-| exists | 200 | 13.325 | 15,009.758 | 0.066 | 0.052 | 0.09 | 0.118 | 0.046 | 2.085 |
-| list (all) | 50 | 96.56 | 517.814 | 1.931 | 1.771 | 4.279 | 6.013 | 1.515 | 6.013 |
-| listPaginated (1, 20) | 200 | 398.616 | 501.736 | 1.993 | 1.765 | 3.022 | 8.919 | 1.51 | 10.708 |
-| query().where().gte().execute() | 100 | 181.336 | 551.463 | 1.813 | 1.599 | 1.896 | 2.042 | 1.524 | 14.147 |
-| delete (single) | 200 | 161.278 | 1,240.095 | 0.806 | 0.773 | 0.896 | 1.019 | 0.64 | 6.043 |
-
+| Operation                       | Ops | Total ms |      Ops/s | Avg ms |   P50 |   P95 |   P99 |   Min |    Max |
+| ------------------------------- | --: | -------: | ---------: | -----: | ----: | ----: | ----: | ----: | -----: |
+| create (single)                 | 200 |   11.668 | 17,141.483 |  0.058 | 0.044 | 0.103 |  0.13 | 0.039 |  0.883 |
+| read (by PK)                    | 200 |    7.972 | 25,087.351 |  0.039 | 0.036 | 0.062 | 0.091 |  0.03 |  0.113 |
+| update (single)                 | 200 |   133.17 |  1,501.843 |  0.665 | 0.615 |  1.01 | 1.184 | 0.545 |  2.036 |
+| findByIndex (email)             | 200 |    8.942 | 22,365.168 |  0.044 | 0.041 | 0.073 | 0.086 | 0.034 |  0.111 |
+| findOneByIndex (email)          | 200 |   10.246 | 19,519.677 |  0.051 | 0.044 | 0.057 | 0.072 | 0.039 |  0.998 |
+| count                           | 200 |     8.28 | 24,155.266 |  0.041 |  0.04 | 0.049 | 0.055 | 0.037 |  0.079 |
+| exists                          | 200 |   13.325 | 15,009.758 |  0.066 | 0.052 |  0.09 | 0.118 | 0.046 |  2.085 |
+| list (all)                      |  50 |    96.56 |    517.814 |  1.931 | 1.771 | 4.279 | 6.013 | 1.515 |  6.013 |
+| listPaginated (1, 20)           | 200 |  398.616 |    501.736 |  1.993 | 1.765 | 3.022 | 8.919 |  1.51 | 10.708 |
+| query().where().gte().execute() | 100 |  181.336 |    551.463 |  1.813 | 1.599 | 1.896 | 2.042 | 1.524 | 14.147 |
+| delete (single)                 | 200 |  161.278 |  1,240.095 |  0.806 | 0.773 | 0.896 | 1.019 |  0.64 |  6.043 |
 
 ### Suite 2: Batched CRUD (by batch size)
 
-| Operation | Ops | Total ms | Ops/s | Avg ms | P50 | P95 | P99 | Min | Max |
-|-----------|-----:|---------:|------:|-------:|----:|----:|----:|----:|----:|
-| createMany (10) | 3 | 1.421 | 2,111.564 | 0.473 | 0.513 | 0.528 | 0.528 | 0.377 | 0.528 |
-| read batch (10 keys) | 3 | 0.5 | 5,998.488 | 0.166 | 0.16 | 0.189 | 0.189 | 0.151 | 0.189 |
-| updateMany (10) | 3 | 4.472 | 670.902 | 1.49 | 1.452 | 1.646 | 1.646 | 1.37 | 1.646 |
-| deleteMany (10) | 3 | 3.163 | 948.378 | 1.054 | 1.054 | 1.139 | 1.139 | 0.969 | 1.139 |
-| deleteWhere (10+ match) | 3 | 0.841 | 3,566.321 | 0.28 | 0.278 | 0.312 | 0.312 | 0.249 | 0.312 |
-| createMany (50) | 3 | 4.301 | 697.531 | 1.433 | 1.433 | 1.477 | 1.477 | 1.39 | 1.477 |
-| read batch (50 keys) | 3 | 3.931 | 763.202 | 1.31 | 1.296 | 1.421 | 1.421 | 1.212 | 1.421 |
-| updateMany (50) | 3 | 87.877 | 34.138 | 29.291 | 29.002 | 31.244 | 31.244 | 27.628 | 31.244 |
-| deleteMany (50) | 3 | 93.633 | 32.04 | 31.21 | 31.53 | 33.2 | 33.2 | 28.899 | 33.2 |
-| deleteWhere (50+ match) | 3 | 3.446 | 870.695 | 1.148 | 1.127 | 1.241 | 1.241 | 1.075 | 1.241 |
-| createMany (100) | 3 | 9.571 | 313.443 | 3.19 | 3.074 | 3.8 | 3.8 | 2.695 | 3.8 |
-| read batch (100 keys) | 3 | 12.769 | 234.949 | 4.255 | 4.077 | 5.665 | 5.665 | 3.023 | 5.665 |
-| updateMany (100) | 3 | 314.564 | 9.537 | 104.853 | 104.907 | 104.963 | 104.963 | 104.69 | 104.963 |
-| deleteMany (100) | 3 | 331.429 | 9.052 | 110.474 | 108.426 | 121.766 | 121.766 | 101.228 | 121.766 |
-| deleteWhere (100+ match) | 3 | 6.954 | 431.435 | 2.317 | 2.254 | 2.481 | 2.481 | 2.216 | 2.481 |
-| createMany (500) | 3 | 88.569 | 33.872 | 29.522 | 27.663 | 42.007 | 42.007 | 18.894 | 42.007 |
-| read batch (500 keys) | 3 | 118.5 | 25.316 | 39.498 | 36.064 | 51.839 | 51.839 | 30.592 | 51.839 |
-| updateMany (500) | 3 | 8,577.818 | 0.35 | 2,859.271 | 2,855.88 | 2,877.442 | 2,877.442 | 2,844.49 | 2,877.442 |
-| deleteMany (500) | 3 | 9,452.42 | 0.317 | 3,150.804 | 3,097.544 | 3,450.784 | 3,450.784 | 2,904.084 | 3,450.784 |
-| deleteWhere (500+ match) | 3 | 35.488 | 84.535 | 11.828 | 11.745 | 12.529 | 12.529 | 11.21 | 12.529 |
-
+| Operation                | Ops |  Total ms |     Ops/s |    Avg ms |       P50 |       P95 |       P99 |       Min |       Max |
+| ------------------------ | --: | --------: | --------: | --------: | --------: | --------: | --------: | --------: | --------: |
+| createMany (10)          |   3 |     1.421 | 2,111.564 |     0.473 |     0.513 |     0.528 |     0.528 |     0.377 |     0.528 |
+| read batch (10 keys)     |   3 |       0.5 | 5,998.488 |     0.166 |      0.16 |     0.189 |     0.189 |     0.151 |     0.189 |
+| updateMany (10)          |   3 |     4.472 |   670.902 |      1.49 |     1.452 |     1.646 |     1.646 |      1.37 |     1.646 |
+| deleteMany (10)          |   3 |     3.163 |   948.378 |     1.054 |     1.054 |     1.139 |     1.139 |     0.969 |     1.139 |
+| deleteWhere (10+ match)  |   3 |     0.841 | 3,566.321 |      0.28 |     0.278 |     0.312 |     0.312 |     0.249 |     0.312 |
+| createMany (50)          |   3 |     4.301 |   697.531 |     1.433 |     1.433 |     1.477 |     1.477 |      1.39 |     1.477 |
+| read batch (50 keys)     |   3 |     3.931 |   763.202 |      1.31 |     1.296 |     1.421 |     1.421 |     1.212 |     1.421 |
+| updateMany (50)          |   3 |    87.877 |    34.138 |    29.291 |    29.002 |    31.244 |    31.244 |    27.628 |    31.244 |
+| deleteMany (50)          |   3 |    93.633 |     32.04 |     31.21 |     31.53 |      33.2 |      33.2 |    28.899 |      33.2 |
+| deleteWhere (50+ match)  |   3 |     3.446 |   870.695 |     1.148 |     1.127 |     1.241 |     1.241 |     1.075 |     1.241 |
+| createMany (100)         |   3 |     9.571 |   313.443 |      3.19 |     3.074 |       3.8 |       3.8 |     2.695 |       3.8 |
+| read batch (100 keys)    |   3 |    12.769 |   234.949 |     4.255 |     4.077 |     5.665 |     5.665 |     3.023 |     5.665 |
+| updateMany (100)         |   3 |   314.564 |     9.537 |   104.853 |   104.907 |   104.963 |   104.963 |    104.69 |   104.963 |
+| deleteMany (100)         |   3 |   331.429 |     9.052 |   110.474 |   108.426 |   121.766 |   121.766 |   101.228 |   121.766 |
+| deleteWhere (100+ match) |   3 |     6.954 |   431.435 |     2.317 |     2.254 |     2.481 |     2.481 |     2.216 |     2.481 |
+| createMany (500)         |   3 |    88.569 |    33.872 |    29.522 |    27.663 |    42.007 |    42.007 |    18.894 |    42.007 |
+| read batch (500 keys)    |   3 |     118.5 |    25.316 |    39.498 |    36.064 |    51.839 |    51.839 |    30.592 |    51.839 |
+| updateMany (500)         |   3 | 8,577.818 |      0.35 | 2,859.271 |  2,855.88 | 2,877.442 | 2,877.442 |  2,844.49 | 2,877.442 |
+| deleteMany (500)         |   3 |  9,452.42 |     0.317 | 3,150.804 | 3,097.544 | 3,450.784 | 3,450.784 | 2,904.084 | 3,450.784 |
+| deleteWhere (500+ match) |   3 |    35.488 |    84.535 |    11.828 |    11.745 |    12.529 |    12.529 |     11.21 |    12.529 |
 
 ### Suite 3: Mixed CRUD Operations
 
-| Operation | Ops | Total ms | Ops/s | Avg ms | P50 | P95 | P99 | Min | Max |
-|-----------|-----:|---------:|------:|-------:|----:|----:|----:|----:|----:|
-| Read-heavy mix (70R/15U/10C/5D) | 200 | 38.005 | 5,262.407 | 0.19 | 0.031 | 0.716 | 0.737 | 0.001 | 0.745 |
-| Write-heavy mix (20R/15U/50C/15D) | 200 | 44.985 | 4,445.915 | 0.225 | 0.035 | 0.707 | 0.739 | 0.001 | 3.708 |
-| Mixed CRUD + queries | 200 | 83.386 | 2,398.49 | 0.417 | 0.033 | 2.061 | 2.141 | 0.011 | 6.234 |
-| Cross-entity mix (User.read + Order.create) | 200 | 6.295 | 31,770.944 | 0.031 | 0.024 | 0.058 | 0.076 | 0.018 | 0.095 |
-
+| Operation                                   | Ops | Total ms |      Ops/s | Avg ms |   P50 |   P95 |   P99 |   Min |   Max |
+| ------------------------------------------- | --: | -------: | ---------: | -----: | ----: | ----: | ----: | ----: | ----: |
+| Read-heavy mix (70R/15U/10C/5D)             | 200 |   38.005 |  5,262.407 |   0.19 | 0.031 | 0.716 | 0.737 | 0.001 | 0.745 |
+| Write-heavy mix (20R/15U/50C/15D)           | 200 |   44.985 |  4,445.915 |  0.225 | 0.035 | 0.707 | 0.739 | 0.001 | 3.708 |
+| Mixed CRUD + queries                        | 200 |   83.386 |   2,398.49 |  0.417 | 0.033 | 2.061 | 2.141 | 0.011 | 6.234 |
+| Cross-entity mix (User.read + Order.create) | 200 |    6.295 | 31,770.944 |  0.031 | 0.024 | 0.058 | 0.076 | 0.018 | 0.095 |
 
 ### Suite 4: Mixed Batched CRUD
 
-| Operation | Ops | Total ms | Ops/s | Avg ms | P50 | P95 | P99 | Min | Max |
-|-----------|-----:|---------:|------:|-------:|----:|----:|----:|----:|----:|
-| Cycle: createMany -> readAll -> updateMany -> deleteMany (50) | 5 | 104.266 | 47.954 | 20.852 | 15.473 | 36.333 | 36.333 | 9.223 | 36.333 |
-| createMany  ->  query filter  ->  deleteMany (50) | 5 | 33.079 | 151.155 | 6.615 | 6.368 | 9.824 | 9.824 | 4.751 | 9.824 |
-| 5 waves × createMany(50) + deleteMany(50) | 3 | 292.584 | 10.253 | 97.527 | 94.694 | 108.554 | 108.554 | 89.333 | 108.554 |
-| Cross-entity batch: createMany(User) + createMany(Order) + deleteMany (×50) | 3 | 136.071 | 22.047 | 45.356 | 43.887 | 49.364 | 49.364 | 42.816 | 49.364 |
-
+| Operation                                                                   | Ops | Total ms |   Ops/s | Avg ms |    P50 |     P95 |     P99 |    Min |     Max |
+| --------------------------------------------------------------------------- | --: | -------: | ------: | -----: | -----: | ------: | ------: | -----: | ------: |
+| Cycle: createMany -> readAll -> updateMany -> deleteMany (50)               |   5 |  104.266 |  47.954 | 20.852 | 15.473 |  36.333 |  36.333 |  9.223 |  36.333 |
+| createMany -> query filter -> deleteMany (50)                               |   5 |   33.079 | 151.155 |  6.615 |  6.368 |   9.824 |   9.824 |  4.751 |   9.824 |
+| 5 waves × createMany(50) + deleteMany(50)                                   |   3 |  292.584 |  10.253 | 97.527 | 94.694 | 108.554 | 108.554 | 89.333 | 108.554 |
+| Cross-entity batch: createMany(User) + createMany(Order) + deleteMany (×50) |   3 |  136.071 |  22.047 | 45.356 | 43.887 |  49.364 |  49.364 | 42.816 |  49.364 |
 
 ### Suite 5: Transaction Operations
 
-| Operation | Ops | Total ms | Ops/s | Avg ms | P50 | P95 | P99 | Min | Max |
-|-----------|-----:|---------:|------:|-------:|----:|----:|----:|----:|----:|
-| tx: single create | 100 | 7.5 | 13,332.676 | 0.075 | 0.063 | 0.121 | 0.209 | 0.06 | 0.37 |
-| tx: create 10 users | 100 | 23.044 | 4,339.529 | 0.23 | 0.219 | 0.27 | 0.413 | 0.207 | 0.455 |
-| tx: read + update | 100 | 194.689 | 513.64 | 1.947 | 1.906 | 1.986 | 3.09 | 1.836 | 5.522 |
-| tx: multi-entity create (User+Order+Session) | 100 | 7.336 | 13,632.137 | 0.073 | 0.07 | 0.098 | 0.114 | 0.066 | 0.159 |
-| tx: 10 reads | 100 | 15.108 | 6,618.828 | 0.151 | 0.141 | 0.176 | 0.272 | 0.135 | 0.364 |
-| tx: batch create 50 users | 20 | 23.258 | 859.911 | 1.163 | 0.953 | 1.68 | 4.091 | 0.926 | 4.091 |
-| tx: query().where().gte() | 100 | 946.761 | 105.623 | 9.467 | 8.473 | 18.988 | 19.246 | 8.265 | 19.705 |
-| tx (explicit): begin -> create -> commit | 100 | 5.381 | 18,582.249 | 0.054 | 0.052 | 0.067 | 0.078 | 0.049 | 0.081 |
-
+| Operation                                    | Ops | Total ms |      Ops/s | Avg ms |   P50 |    P95 |    P99 |   Min |    Max |
+| -------------------------------------------- | --: | -------: | ---------: | -----: | ----: | -----: | -----: | ----: | -----: |
+| tx: single create                            | 100 |      7.5 | 13,332.676 |  0.075 | 0.063 |  0.121 |  0.209 |  0.06 |   0.37 |
+| tx: create 10 users                          | 100 |   23.044 |  4,339.529 |   0.23 | 0.219 |   0.27 |  0.413 | 0.207 |  0.455 |
+| tx: read + update                            | 100 |  194.689 |     513.64 |  1.947 | 1.906 |  1.986 |   3.09 | 1.836 |  5.522 |
+| tx: multi-entity create (User+Order+Session) | 100 |    7.336 | 13,632.137 |  0.073 |  0.07 |  0.098 |  0.114 | 0.066 |  0.159 |
+| tx: 10 reads                                 | 100 |   15.108 |  6,618.828 |  0.151 | 0.141 |  0.176 |  0.272 | 0.135 |  0.364 |
+| tx: batch create 50 users                    |  20 |   23.258 |    859.911 |  1.163 | 0.953 |   1.68 |  4.091 | 0.926 |  4.091 |
+| tx: query().where().gte()                    | 100 |  946.761 |    105.623 |  9.467 | 8.473 | 18.988 | 19.246 | 8.265 | 19.705 |
+| tx (explicit): begin -> create -> commit     | 100 |    5.381 | 18,582.249 |  0.054 | 0.052 |  0.067 |  0.078 | 0.049 |  0.081 |
 
 ### Suite 6: Mixed Transactions
 
-| Operation | Ops | Total ms | Ops/s | Avg ms | P50 | P95 | P99 | Min | Max |
-|-----------|-----:|---------:|------:|-------:|----:|----:|----:|----:|----:|
-| tx mixed: read User  ->  create Order  ->  update User | 100 | 53.926 | 1,854.389 | 0.539 | 0.437 | 0.462 | 0.59 | 0.41 | 10.318 |
-| tx mixed: query User + read Order + create Session | 100 | 113.792 | 878.798 | 1.138 | 1.055 | 1.088 | 1.139 | 1.03 | 8.959 |
-| tx multi-entity: create User+Order+Session | 100 | 8.889 | 11,250.085 | 0.089 | 0.087 | 0.102 | 0.106 | 0.082 | 0.132 |
-| tx batched: create 20 Users + 40 Orders + 20 Sessions | 10 | 20.246 | 493.934 | 2.024 | 1.136 | 9.953 | 9.953 | 1.096 | 9.953 |
-| tx mixed: delete old orders  ->  create new orders | 100 | 122.343 | 817.377 | 1.223 | 1.145 | 1.309 | 1.386 | 0.981 | 8.579 |
-| tx mixed: count Orders  ->  conditional create | 100 | 7.079 | 14,125.357 | 0.071 | 0.069 | 0.083 | 0.099 | 0.065 | 0.103 |
-| tx complex: read User+Orders  ->  aggregate  ->  create Session | 100 | 15.71 | 6,365.173 | 0.157 | 0.117 | 0.216 | 0.33 | 0.107 | 2.822 |
+| Operation                                                   | Ops | Total ms |      Ops/s | Avg ms |   P50 |   P95 |   P99 |   Min |    Max |
+| ----------------------------------------------------------- | --: | -------: | ---------: | -----: | ----: | ----: | ----: | ----: | -----: |
+| tx mixed: read User -> create Order -> update User          | 100 |   53.926 |  1,854.389 |  0.539 | 0.437 | 0.462 |  0.59 |  0.41 | 10.318 |
+| tx mixed: query User + read Order + create Session          | 100 |  113.792 |    878.798 |  1.138 | 1.055 | 1.088 | 1.139 |  1.03 |  8.959 |
+| tx multi-entity: create User+Order+Session                  | 100 |    8.889 | 11,250.085 |  0.089 | 0.087 | 0.102 | 0.106 | 0.082 |  0.132 |
+| tx batched: create 20 Users + 40 Orders + 20 Sessions       |  10 |   20.246 |    493.934 |  2.024 | 1.136 | 9.953 | 9.953 | 1.096 |  9.953 |
+| tx mixed: delete old orders -> create new orders            | 100 |  122.343 |    817.377 |  1.223 | 1.145 | 1.309 | 1.386 | 0.981 |  8.579 |
+| tx mixed: count Orders -> conditional create                | 100 |    7.079 | 14,125.357 |  0.071 | 0.069 | 0.083 | 0.099 | 0.065 |  0.103 |
+| tx complex: read User+Orders -> aggregate -> create Session | 100 |    15.71 |  6,365.173 |  0.157 | 0.117 | 0.216 |  0.33 | 0.107 |  2.822 |
 
 <!-- performance end -->
 

--- a/__tests__/schema-migration.test.ts
+++ b/__tests__/schema-migration.test.ts
@@ -1,0 +1,152 @@
+import { Database, DataClass, KeyPath, Index } from '../index';
+
+/**
+ * Builds a fresh entity class at runtime so the same store name can be
+ * redeclared with a different shape between `Database.build` calls -
+ * exactly what happens across app releases.
+ */
+const defineEntity = (
+  name: string,
+  indexes: string[] = [],
+  version = 1,
+): any => {
+  class Entity {
+    id!: string;
+    [field: string]: any;
+  }
+
+  Object.defineProperty(Entity, 'name', { value: name });
+  KeyPath()(Entity.prototype, 'id');
+  indexes.forEach((field) => Index()(Entity.prototype, field));
+  DataClass({ version })(Entity as any);
+  return Entity;
+};
+
+const destroyDatabase = (name: string): Promise<void> =>
+  new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+
+describe('Schema migration lifecycle', () => {
+  describe('index added without a version bump', () => {
+    const dbName = 'MigrationAddIndexDB';
+
+    beforeAll(() => destroyDatabase(dbName));
+
+    it('creates the new index via drift detection', async () => {
+      const V1 = defineEntity('Note', []);
+      let db: any = await Database.build(dbName, [V1]);
+      await db.Note.create({ id: 'n1', tag: 'idea' });
+      db.close();
+
+      const V2 = defineEntity('Note', ['tag']);
+      db = await Database.build(dbName, [V2]);
+
+      const matches = await db.Note.findByIndex('tag', 'idea');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('n1');
+      db.close();
+    });
+  });
+
+  describe('index removed without a version bump', () => {
+    const dbName = 'MigrationRemoveIndexDB';
+
+    beforeAll(() => destroyDatabase(dbName));
+
+    it('drops the stale index and preserves the data', async () => {
+      const V1 = defineEntity('Doc', ['email']);
+      let db: any = await Database.build(dbName, [V1]);
+      await db.Doc.create({ id: 'd1', email: 'a@example.com' });
+
+      // Sanity check: index works before removal.
+      const before = await db.Doc.findByIndex('email', 'a@example.com');
+      expect(before).toHaveLength(1);
+      db.close();
+
+      const V2 = defineEntity('Doc', []);
+      db = await Database.build(dbName, [V2]);
+
+      await expect(
+        db.Doc.findByIndex('email', 'a@example.com'),
+      ).rejects.toThrow("Index 'email' does not exist");
+
+      // Records survive the index removal.
+      const doc = await db.Doc.read('d1');
+      expect(doc?.email).toBe('a@example.com');
+      db.close();
+    });
+  });
+
+  describe('entity version lowered', () => {
+    const dbName = 'MigrationDowngradeDB';
+
+    beforeAll(() => destroyDatabase(dbName));
+
+    it('opens at the persisted version instead of throwing VersionError', async () => {
+      const High = defineEntity('Item', [], 5);
+      let db: any = await Database.build(dbName, [High]);
+      expect(db.getDatabaseVersion()).toBe(5);
+      await db.Item.create({ id: 'i1', label: 'kept' });
+      db.close();
+
+      const Low = defineEntity('Item', [], 2);
+      db = await Database.build(dbName, [Low]);
+
+      // IndexedDB cannot downgrade - the persisted version wins.
+      expect(db.getDatabaseVersion()).toBe(5);
+      const item = await db.Item.read('i1');
+      expect(item?.label).toBe('kept');
+      db.close();
+    });
+  });
+
+  describe('orphaned stores', () => {
+    const dbName = 'MigrationOrphanDB';
+
+    beforeAll(() => destroyDatabase(dbName));
+
+    it('preserves stores whose entity is no longer registered', async () => {
+      const Keep = defineEntity('Kept', []);
+      const Drop = defineEntity('Dropped', []);
+      let db: any = await Database.build(dbName, [Keep, Drop]);
+      await db.Dropped.create({ id: 'x1', payload: 'still-here' });
+      db.close();
+
+      // Rebuild without the Dropped entity - its store must survive.
+      const KeepAgain = defineEntity('Kept', []);
+      db = await Database.build(dbName, [KeepAgain]);
+      expect(db.getAvailableEntities()).toEqual(['Kept']);
+      db.close();
+
+      // Re-registering the entity finds the original data intact.
+      const KeepFinal = defineEntity('Kept', []);
+      const DropFinal = defineEntity('Dropped', []);
+      db = await Database.build(dbName, [KeepFinal, DropFinal]);
+      const record = await db.Dropped.read('x1');
+      expect(record?.payload).toBe('still-here');
+      db.close();
+    });
+  });
+
+  describe('stable schema', () => {
+    const dbName = 'MigrationStableDB';
+
+    beforeAll(() => destroyDatabase(dbName));
+
+    it('does not bump the version when nothing changed', async () => {
+      const V1 = defineEntity('Stable', ['kind'], 3);
+      let db: any = await Database.build(dbName, [V1]);
+      expect(db.getDatabaseVersion()).toBe(3);
+      db.close();
+
+      const V1Again = defineEntity('Stable', ['kind'], 3);
+      db = await Database.build(dbName, [V1Again]);
+      expect(db.getDatabaseVersion()).toBe(3);
+      db.close();
+    });
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -87,8 +87,8 @@ type ArrayElement<T> = T extends readonly (infer U)[] ? U : never;
 type ContainsValue<T> = T extends string
   ? string
   : T extends readonly (infer U)[]
-  ? U
-  : never;
+    ? U
+    : never;
 
 /**
  * All filter operators supported by {@link FieldQueryBuilder} and {@link QueryBuilder}.
@@ -210,7 +210,7 @@ class FieldQueryBuilder<T, K extends QueryFieldKey<T>> {
   constructor(
     private parent: QueryBuilder<T>,
     private field: K,
-  ) { }
+  ) {}
 
   /**
    * Filters records where `field === value`.
@@ -879,8 +879,8 @@ class QueryBuilder<T> {
     const store = this.transaction
       ? this.transaction.objectStore(this.storeName)
       : this.db
-        .transaction(this.storeName, 'readonly')
-        .objectStore(this.storeName);
+          .transaction(this.storeName, 'readonly')
+          .objectStore(this.storeName);
 
     const request = this.createReadRequest(store);
     return new Promise<T[]>((resolve, reject) => {
@@ -1209,10 +1209,10 @@ interface KeyPathOptions {
    *                   `string` or `number`.
    */
   generator?:
-  | 'uuid'
-  | 'timestamp'
-  | 'random'
-  | ((item?: any) => string | number);
+    | 'uuid'
+    | 'timestamp'
+    | 'random'
+    | ((item?: any) => string | number);
 }
 
 /**
@@ -1860,6 +1860,247 @@ type TransactionalDatabase<T extends Record<string, EntityRepository<any>>> =
  */
 type DatabaseWithRepositories<T extends Record<string, any>> = Database & T;
 
+// ─── Schema Migration ────────────────────────────────────────────────────────
+
+/**
+ * Normalised index definition carried by an {@link EntitySchema}.
+ *
+ * @internal
+ */
+interface EntityIndexSchema {
+  /** Index (and covered field) name. */
+  name: string;
+  /** Resolved IDB index parameters. */
+  options: IDBIndexParameters;
+}
+
+/**
+ * Immutable, declarative description of the IndexedDB object store an entity
+ * class expects. Built once from decorator metadata and treated as the single
+ * source of truth during migration, replacing scattered `Reflect.getMetadata`
+ * reads.
+ *
+ * @internal
+ */
+class EntitySchema {
+  private constructor(
+    /** Entity class name, e.g. `User`. */
+    readonly className: string,
+    /** Object store name (lower-cased class name). */
+    readonly storeName: string,
+    /** Declared schema version (defaults to `1`). */
+    readonly version: number,
+    /** Declared key path, or `undefined` for out-of-line keys. */
+    readonly keyPath: string | string[] | undefined,
+    /** Whether the store uses an IDB key generator. */
+    readonly autoIncrement: boolean,
+    /** Declared secondary indexes. */
+    readonly indexes: ReadonlyArray<EntityIndexSchema>,
+  ) {}
+
+  /** Builds the schema for a `@DataClass`-decorated constructor. */
+  static fromClass(cls: Function): EntitySchema {
+    const keyPathMetadata = Reflect.getMetadata('keypath', cls) as
+      | KeyPathMetadata
+      | undefined;
+    const rawIndexes = (Reflect.getMetadata('indexes', cls) || []) as Array<
+      string | IndexMetadata
+    >;
+    const indexes = rawIndexes.map((entry) =>
+      typeof entry === 'string'
+        ? { name: entry, options: { unique: false } }
+        : { name: entry.field, options: entry.options ?? { unique: false } },
+    );
+
+    return new EntitySchema(
+      cls.name,
+      cls.name.toLowerCase(),
+      Reflect.getMetadata('version', cls) || 1,
+      keyPathMetadata?.fields,
+      keyPathMetadata?.options?.autoIncrement === true,
+      indexes,
+    );
+  }
+
+  /** Whether this schema declares an index with the given name. */
+  hasIndex(name: string): boolean {
+    return this.indexes.some((index) => index.name === name);
+  }
+}
+
+/**
+ * Applies a set of {@link EntitySchema} definitions to an IndexedDB database.
+ *
+ * The migrator is fully declarative and idempotent: inside a version-change
+ * transaction it reconciles the *actual* schema with the *declared* one -
+ * creating missing stores, adding missing indexes, and **removing indexes that
+ * are no longer declared**. Because the sync no longer depends on per-entity
+ * version comparisons, schema changes are honoured even when the author
+ * forgets to bump an entity's `version`.
+ *
+ * Changes that cannot be applied without data loss (key-path or
+ * auto-increment changes, stores with no registered entity) are never
+ * performed automatically; they are surfaced through the error logger so the
+ * application author can migrate the data explicitly.
+ *
+ * @internal
+ */
+class SchemaMigrator {
+  constructor(
+    private readonly schemas: ReadonlyArray<EntitySchema>,
+    private readonly logDebug: (...data: any[]) => void,
+    private readonly logWarn: (...data: any[]) => void,
+  ) {}
+
+  /** Highest declared entity version - the minimum database version. */
+  get targetVersion(): number {
+    return Math.max(1, ...this.schemas.map((schema) => schema.version));
+  }
+
+  /**
+   * Reconciles every declared schema against the open database. Must be
+   * called from within an `onupgradeneeded` handler.
+   *
+   * @param db          - The database being upgraded.
+   * @param transaction - The active version-change transaction.
+   */
+  applyTo(db: IDBDatabase, transaction: IDBTransaction | null): void {
+    this.schemas.forEach((schema) => {
+      if (!db.objectStoreNames.contains(schema.storeName)) {
+        this.createStore(db, schema);
+      } else if (transaction) {
+        this.syncStore(transaction.objectStore(schema.storeName), schema);
+      }
+    });
+
+    this.reportOrphanedStores(db);
+  }
+
+  /**
+   * Compares the actual database schema against the declared one and returns
+   * a description of every difference that a re-run of {@link applyTo} can
+   * repair (missing stores, missing indexes, stale indexes).
+   *
+   * Differences that require destructive action (key-path changes, orphaned
+   * stores) are intentionally excluded so callers do not loop attempting to
+   * fix the unfixable.
+   *
+   * @param db - An open database connection.
+   * @returns Human-readable drift descriptions; empty when in sync.
+   */
+  detectFixableDrift(db: IDBDatabase): string[] {
+    const drift: string[] = [];
+    const existing = this.schemas.filter((schema) =>
+      db.objectStoreNames.contains(schema.storeName),
+    );
+
+    this.schemas.forEach((schema) => {
+      if (!db.objectStoreNames.contains(schema.storeName)) {
+        drift.push(`missing object store '${schema.storeName}'`);
+      }
+    });
+
+    if (existing.length) {
+      const transaction = db.transaction(
+        existing.map((schema) => schema.storeName),
+        'readonly',
+      );
+
+      existing.forEach((schema) => {
+        const store = transaction.objectStore(schema.storeName);
+
+        schema.indexes.forEach(({ name }) => {
+          if (!store.indexNames.contains(name)) {
+            drift.push(`missing index '${name}' on '${schema.storeName}'`);
+          }
+        });
+
+        Array.from(store.indexNames).forEach((name) => {
+          if (!schema.hasIndex(name)) {
+            drift.push(`stale index '${name}' on '${schema.storeName}'`);
+          }
+        });
+      });
+    }
+
+    return drift;
+  }
+
+  /** @internal */
+  private createStore(db: IDBDatabase, schema: EntitySchema): void {
+    const options: IDBObjectStoreParameters = {};
+    if (schema.keyPath !== undefined) {
+      options.keyPath = schema.keyPath as string | string[];
+    }
+    if (schema.autoIncrement) {
+      options.autoIncrement = true;
+    }
+
+    const store = db.createObjectStore(schema.storeName, options);
+    schema.indexes.forEach(({ name, options: indexOptions }) => {
+      store.createIndex(name, name, indexOptions);
+    });
+
+    this.logDebug(
+      `Created object store '${schema.storeName}' (entity version ${schema.version})`,
+    );
+  }
+
+  /** @internal */
+  private syncStore(store: IDBObjectStore, schema: EntitySchema): void {
+    if (!this.keyPathMatches(store, schema)) {
+      this.logWarn(
+        `Key path of object store '${schema.storeName}' differs from the ` +
+          `declaration on ${schema.className}. IndexedDB cannot change a ` +
+          'store\'s key path in place; migrate the data to a new entity or ' +
+          'delete the database to apply this change.',
+      );
+    }
+
+    schema.indexes.forEach(({ name, options }) => {
+      if (!store.indexNames.contains(name)) {
+        store.createIndex(name, name, options);
+        this.logDebug(`Added index '${name}' to '${schema.storeName}'`);
+      }
+    });
+
+    Array.from(store.indexNames).forEach((name) => {
+      if (!schema.hasIndex(name)) {
+        store.deleteIndex(name);
+        this.logDebug(
+          `Removed stale index '${name}' from '${schema.storeName}'`,
+        );
+      }
+    });
+  }
+
+  /** @internal */
+  private keyPathMatches(store: IDBObjectStore, schema: EntitySchema): boolean {
+    const normalise = (
+      keyPath: string | string[] | null | undefined,
+    ): string => (Array.isArray(keyPath) ? keyPath.join(',') : (keyPath ?? ''));
+
+    return (
+      normalise(store.keyPath) === normalise(schema.keyPath) &&
+      store.autoIncrement === schema.autoIncrement
+    );
+  }
+
+  /** @internal */
+  private reportOrphanedStores(db: IDBDatabase): void {
+    const declared = new Set(this.schemas.map((schema) => schema.storeName));
+    Array.from(db.objectStoreNames).forEach((storeName) => {
+      if (!declared.has(storeName)) {
+        this.logWarn(
+          `Object store '${storeName}' has no registered entity class. ` +
+            'Its data is preserved; register the entity again or delete the ' +
+            'store manually if it is no longer needed.',
+        );
+      }
+    });
+  }
+}
+
 // ─── Database ────────────────────────────────────────────────────────────────
 
 /**
@@ -1871,11 +2112,18 @@ type DatabaseWithRepositories<T extends Record<string, any>> = Database & T;
  * is private.
  *
  * @remarks
- * **Schema versioning.** The effective database version is the highest
- * `version` value across all registered `@DataClass` entities. On each
- * `onupgradeneeded` event, only stores whose `version` exceeds the previous
- * database version are created or updated, so additive schema evolution is
- * handled automatically.
+ * **Schema versioning.** The declared database version is the highest
+ * `version` value across all registered `@DataClass` entities. On every
+ * `onupgradeneeded` event the full declared schema is reconciled against the
+ * actual one: missing stores and indexes are created and indexes that are no
+ * longer declared are removed. If the schema changed without a version bump,
+ * the drift is detected after opening and a follow-up upgrade is triggered
+ * automatically. If the declared version is *lower* than the version stored
+ * on disk (an entity's `version` was decreased), the database opens at the
+ * existing on-disk version instead of failing with a `VersionError` -
+ * IndexedDB cannot downgrade. Changes that would require destructive action
+ * (key-path changes, stores whose entity is no longer registered) are never
+ * applied automatically; they are reported through the error log instead.
  *
  * **Retention cleanup.** When entities declare `@RetentionPolicy`, a periodic
  * `setInterval` job is started after the database opens. The interval is the
@@ -1904,6 +2152,8 @@ type DatabaseWithRepositories<T extends Record<string, any>> = Database & T;
 class Database {
   private dbName: string;
   private classes: Function[];
+  private schemas: EntitySchema[];
+  private migrator: SchemaMigrator;
   private db: IDBDatabase | null = null;
   private entityRepositories: Map<string, any> = new Map();
   private dbVersion: number;
@@ -1923,8 +2173,7 @@ class Database {
    * @internal
    */
   private printDebug = (...data: any) => {
-    if (!this.printEnabled)
-      return;
+    if (!this.printEnabled) return;
     console.debug('[idb-ts]:DEBUG:', ...data);
   };
 
@@ -1935,20 +2184,29 @@ class Database {
    * @internal
    */
   private printError = (...error: any) => {
-    if (!this.printEnabled)
-      return;
+    if (!this.printEnabled) return;
     console.error('[idb-ts]:ERROR:', ...error);
   };
 
   /** @internal Use {@link Database.build} to create instances. */
-  private constructor(dbName: string, classes: Function[], printEnabled = false) {
+  private constructor(
+    dbName: string,
+    classes: Function[],
+    printEnabled = false,
+  ) {
     this.dbName = dbName;
     this.printEnabled = printEnabled;
     if (!classes.every((cls) => Reflect.getMetadata('dataclass', cls))) {
       throw new Error('All classes should be decorated with @DataClass.');
     }
     this.classes = classes;
-    this.dbVersion = this.calculateDatabaseVersion();
+    this.schemas = classes.map((cls) => EntitySchema.fromClass(cls));
+    this.migrator = new SchemaMigrator(
+      this.schemas,
+      this.printDebug,
+      this.printError,
+    );
+    this.dbVersion = this.migrator.targetVersion;
     this.retentionPolicies = this.classes
       .map((cls) => {
         const policy = Reflect.getMetadata('retention_policy', cls) as
@@ -1976,18 +2234,77 @@ class Database {
   }
 
   /**
-   * Derives the IDB database version from the highest `version` annotation
-   * across all registered entity classes.
+   * Reads the version currently persisted on disk for this database name
+   * without creating or upgrading it.
    *
-   * @returns The calculated database version number.
+   * Prefers `indexedDB.databases()` where available; otherwise falls back to
+   * a probe `open()` whose version-change transaction is aborted immediately
+   * so a non-existent database is not created as a side effect.
+   *
+   * @returns The persisted version, or `0` when the database does not exist.
    * @internal
    */
-  private calculateDatabaseVersion(): number {
-    // Calculate the database version based on the highest schema version
-    const versions = this.classes.map(
-      (cls) => Reflect.getMetadata('version', cls) || 1,
-    );
-    return Math.max(...versions);
+  private async readPersistedVersion(): Promise<number> {
+    const databasesFn = (indexedDB as any).databases as
+      | (() => Promise<Array<{ name?: string; version?: number }>>)
+      | undefined;
+
+    if (typeof databasesFn === 'function') {
+      try {
+        const infos = await databasesFn.call(indexedDB);
+        const info = infos.find((entry) => entry.name === this.dbName);
+        return info?.version ?? 0;
+      } catch {
+        // Fall through to the probe strategy below.
+      }
+    }
+
+    return new Promise<number>((resolve) => {
+      const request = indexedDB.open(this.dbName);
+
+      request.onupgradeneeded = () => {
+        // The database does not exist; abort so the probe leaves no trace.
+        request.transaction?.abort();
+        resolve(0);
+      };
+      request.onsuccess = () => {
+        const version = request.result.version;
+        request.result.close();
+        resolve(version);
+      };
+      request.onerror = () => resolve(0);
+    });
+  }
+
+  /**
+   * Opens the database at the given version, delegating schema work to the
+   * {@link SchemaMigrator} when an upgrade is required.
+   *
+   * @internal
+   */
+  private openConnection(version: number): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(this.dbName, version);
+
+      request.onupgradeneeded = (event) => {
+        this.printDebug(
+          `Database upgrade from version ${event.oldVersion} to ${event.newVersion ?? version}`,
+        );
+        this.migrator.applyTo(request.result, request.transaction);
+      };
+
+      request.onblocked = () => {
+        this.printDebug(
+          `Opening '${this.dbName}' at version ${version} is blocked by another open connection.`,
+        );
+      };
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => {
+        this.printError('Error initializing database:', request.error);
+        reject(request.error);
+      };
+    });
   }
 
   /**
@@ -2025,110 +2342,51 @@ class Database {
     return instance as DatabaseWithRepositories<T>;
   }
 
-  /** @internal */
+  /**
+   * Opens the database using a downgrade-safe, drift-aware strategy:
+   *
+   * 1. Read the version persisted on disk and open at
+   *    `max(declaredVersion, persistedVersion)`. This makes lowering an
+   *    entity's `version` a non-fatal no-op instead of a `VersionError` -
+   *    IndexedDB cannot downgrade a database.
+   * 2. After opening, compare the actual schema against the declared one.
+   *    If a fixable difference exists (an index was added or removed without
+   *    a version bump), close and reopen at `version + 1` so the
+   *    {@link SchemaMigrator} can reconcile inside an upgrade transaction.
+   *
+   * @internal
+   */
   private async initDB(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this.dbName, this.dbVersion);
+    const persistedVersion = await this.readPersistedVersion();
+    if (persistedVersion > this.dbVersion) {
+      this.printDebug(
+        `Declared schema version ${this.dbVersion} is lower than the ` +
+          `persisted database version ${persistedVersion}. IndexedDB cannot ` +
+          `downgrade; opening at version ${persistedVersion}.`,
+      );
+    }
 
-      request.onupgradeneeded = (event) => {
-        const db = request.result;
-        const oldVersion = event.oldVersion;
-        const newVersion = event.newVersion || this.dbVersion;
+    let db = await this.openConnection(
+      Math.max(this.dbVersion, persistedVersion),
+    );
 
-        this.printDebug(
-          `Database upgrade from version ${oldVersion} to ${newVersion}`,
-        );
+    const drift = this.migrator.detectFixableDrift(db);
+    if (drift.length > 0) {
+      this.printDebug(
+        `Schema drift detected without a version bump: ${drift.join('; ')}. ` +
+          `Reopening at version ${db.version + 1} to reconcile.`,
+      );
+      const nextVersion = db.version + 1;
+      db.close();
+      db = await this.openConnection(nextVersion);
+    }
 
-        // Handle schema evolution based on versions
-        this.classes.forEach((cls) => {
-          const keyPathMetadata = Reflect.getMetadata(
-            'keypath',
-            cls,
-          ) as KeyPathMetadata;
-          const indexFields = Reflect.getMetadata('indexes', cls) || [];
-          const classVersion = Reflect.getMetadata('version', cls) || 1;
-
-          const storeName = cls.name.toLowerCase();
-
-          // Only create/update stores for classes whose version is greater than the old DB version
-          if (classVersion > oldVersion) {
-            if (!db.objectStoreNames.contains(storeName)) {
-              this.printDebug(
-                `Creating object store: ${storeName} (version ${classVersion})`,
-              );
-
-              // Determine store options based on keypath metadata
-              const storeOptions: IDBObjectStoreParameters = {};
-
-              if (keyPathMetadata) {
-                storeOptions.keyPath = keyPathMetadata.fields;
-
-                // Handle auto-increment option
-                if (keyPathMetadata.options?.autoIncrement) {
-                  storeOptions.autoIncrement = true;
-                }
-              }
-
-              const store = db.createObjectStore(storeName, storeOptions);
-
-              indexFields.forEach((indexField: string | IndexMetadata) => {
-                const indexName =
-                  typeof indexField === 'string'
-                    ? indexField
-                    : indexField.field;
-                const indexOptions =
-                  typeof indexField === 'string'
-                    ? { unique: false }
-                    : (indexField.options ?? { unique: false });
-
-                if (!store.indexNames.contains(indexName)) {
-                  store.createIndex(indexName, indexName, indexOptions);
-                }
-              });
-            } else {
-              // Store exists, check if we need to update indexes
-              this.printDebug(
-                `Updating object store: ${storeName} (version ${classVersion})`,
-              );
-              const transaction = request.transaction;
-              if (transaction) {
-                const store = transaction.objectStore(storeName);
-
-                indexFields.forEach((indexField: string | IndexMetadata) => {
-                  const indexName =
-                    typeof indexField === 'string'
-                      ? indexField
-                      : indexField.field;
-                  const indexOptions =
-                    typeof indexField === 'string'
-                      ? { unique: false }
-                      : (indexField.options ?? { unique: false });
-
-                  if (!store.indexNames.contains(indexName)) {
-                    this.printDebug(`Adding index: ${indexName} to ${storeName}`);
-                    store.createIndex(indexName, indexName, indexOptions);
-                  }
-                });
-              }
-            }
-          }
-        });
-      };
-
-      request.onsuccess = () => {
-        this.db = request.result;
-        this.printDebug(
-          `Database initialized (version ${this.dbVersion}) with object stores for: ${this.classes.map((cls) => `${cls.name}(v${Reflect.getMetadata('version', cls) || 1})`).join(', ')}`,
-        );
-        this.startRetentionCleanup();
-        resolve();
-      };
-
-      request.onerror = () => {
-        this.printError('Error initializing database:', request.error);
-        reject(request.error);
-      };
-    });
+    this.db = db;
+    this.dbVersion = db.version;
+    this.printDebug(
+      `Database initialized (version ${this.dbVersion}) with object stores for: ${this.schemas.map((schema) => `${schema.className}(v${schema.version})`).join(', ')}`,
+    );
+    this.startRetentionCleanup();
   }
 
   /** @internal */
@@ -2260,7 +2518,7 @@ class Database {
             deleteRequest.onerror = () =>
               reject(
                 deleteRequest.error ??
-                new Error(`Retention cleanup delete failed for ${className}`),
+                  new Error(`Retention cleanup delete failed for ${className}`),
               );
             return;
           }
@@ -2272,12 +2530,12 @@ class Database {
         transaction.onerror = () =>
           reject(
             transaction.error ??
-            new Error(`Retention cleanup failed for ${className}`),
+              new Error(`Retention cleanup failed for ${className}`),
           );
         transaction.onabort = () =>
           reject(
             transaction.error ??
-            new Error(`Retention cleanup aborted for ${className}`),
+              new Error(`Retention cleanup aborted for ${className}`),
           );
       } catch (error) {
         reject(error);
@@ -2948,8 +3206,12 @@ class Database {
   }
 
   /**
-   * Returns the current IDB database version, derived from the highest
-   * `version` annotation across all registered entities.
+   * Returns the actual version of the open IDB database.
+   *
+   * This is usually the highest `version` annotation across all registered
+   * entities, but can be higher when the on-disk database was created at a
+   * greater version (downgrades are ignored) or when a schema change without
+   * a version bump triggered an automatic reconciliation upgrade.
    *
    * @returns The database version number.
    */


### PR DESCRIPTION
- introduced EntitySchema value object and SchemaMigrator abstraction
- migration now reconciles the full declared schema on every upgrade: creates missing stores/indexes and removes stale indexes
- schema drift without a version bump triggers an automatic reconciling reopen at version+1
- lowering an entity version opens at the persisted version instead of throwing VersionError
- keypath changes and orphaned stores are reported, never destroyed
- documented migration behaviour in README

closes #33 