### PR TITLE
fix: consistent lexical `this` in entity repository

### DIFF
--- a/__tests__/repository-context.test.ts
+++ b/__tests__/repository-context.test.ts
@@ -1,0 +1,51 @@
+import { Database, DataClass, KeyPath } from '../index';
+
+@DataClass()
+class ContextUser {
+  @KeyPath()
+  id!: string;
+
+  name!: string;
+
+  constructor(id: string, name: string) {
+    this.id = id;
+    this.name = name;
+  }
+}
+
+describe('Repository `this` binding consistency', () => {
+  let db: any;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('ContextTestDB');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    });
+    db = await Database.build('ContextTestDB', [ContextUser]);
+  });
+
+  afterAll(() => db.close());
+
+  it('methods work when destructured off the repository', async () => {
+    const { create, read, list, count, query } = db.ContextUser;
+
+    await create(new ContextUser('c1', 'Alice'));
+    const user = await read('c1');
+    expect(user?.name).toBe('Alice');
+
+    const all = await list();
+    expect(all).toHaveLength(1);
+    expect(await count()).toBe(1);
+
+    const results = await query().where('name').equals('Alice').execute();
+    expect(results).toHaveLength(1);
+  });
+
+  it('query() uses the database connection via lexical this', async () => {
+    const detachedQuery = db.ContextUser.query;
+    const builder = detachedQuery();
+    const results = await builder.where('id').equals('c1').execute();
+    expect(results).toHaveLength(1);
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -2290,7 +2290,6 @@ class Database {
     cls: Function,
     transaction?: IDBTransaction,
   ): EntityRepository<T> {
-    const self = this;
     const creationTimestampField = INTERNAL_CREATED_AT_FIELD;
     const updateTimestampField = INTERNAL_UPDATED_AT_FIELD;
     const validators = (Reflect.getMetadata('validators', cls) ||
@@ -2446,10 +2445,10 @@ class Database {
     };
 
     return {
-      query(): QueryBuilder<T> {
-        if (!self.db) throw new Error('Database not initialized.');
+      query: (): QueryBuilder<T> => {
+        if (!this.db) throw new Error('Database not initialized.');
         const storeName = cls.name.toLowerCase();
-        return new QueryBuilder<T>(self.db, storeName, transaction);
+        return new QueryBuilder<T>(this.db, storeName, transaction);
       },
 
       create: async (item: T): Promise<void> => {


### PR DESCRIPTION
Closes #28

## What
The repository factory in `createEntityRepository` used a `const self = this;` alias, but only the `query()` shorthand method actually needed it — every other member is an arrow function capturing the lexical `this` (the `Database` instance).

## Change (minimal)
- Converted `query()` from an object shorthand method to an arrow property, so it captures the same lexical `this` as all sibling members.
- Removed the now-unneeded `self` alias — `this` is used consistently everywhere.

As a side benefit, `query` is now safe to destructure off the repository like every other method.

## Tests
New `__tests__/repository-context.test.ts`:
- all repository methods work when destructured
- a detached `query` reference still resolves the database connection

Full suite: 13 suites / 99 tests green. No behavioural change otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)