### PR TITLE
feat: `getKeys()` repository method

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ await db.User.deleteWhere((q) => q.where('age').lt(18));
 // Utilities
 const count = await db.User.count();
 const exists = await db.User.exists('u1');
+const keys = await db.User.getKeys(); // primary keys only, no record values
 await db.User.clear();
 ```
 

--- a/__tests__/getkeys.test.ts
+++ b/__tests__/getkeys.test.ts
@@ -1,0 +1,70 @@
+import { Database, DataClass, KeyPath, CompositeKeyPath } from '../index';
+
+@DataClass()
+class KeyedItem {
+  @KeyPath()
+  id!: string;
+
+  label!: string;
+
+  constructor(id: string, label: string) {
+    this.id = id;
+    this.label = label;
+  }
+}
+
+@DataClass()
+@CompositeKeyPath(['userId', 'projectId'])
+class Membership {
+  userId!: string;
+  projectId!: string;
+
+  constructor(userId: string, projectId: string) {
+    this.userId = userId;
+    this.projectId = projectId;
+  }
+}
+
+describe('EntityRepository.getKeys', () => {
+  let db: any;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('GetKeysTestDB');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    });
+    db = await Database.build('GetKeysTestDB', [KeyedItem, Membership]);
+  });
+
+  afterAll(() => db.close());
+
+  it('returns an empty array for an empty store', async () => {
+    expect(await db.KeyedItem.getKeys()).toEqual([]);
+  });
+
+  it('returns only the primary keys, not the records', async () => {
+    await db.KeyedItem.create(new KeyedItem('a', 'first'));
+    await db.KeyedItem.create(new KeyedItem('b', 'second'));
+    await db.KeyedItem.create(new KeyedItem('c', 'third'));
+
+    const keys = await db.KeyedItem.getKeys();
+    expect(keys).toEqual(['a', 'b', 'c']);
+  });
+
+  it('reflects deletions', async () => {
+    await db.KeyedItem.delete('b');
+    expect(await db.KeyedItem.getKeys()).toEqual(['a', 'c']);
+  });
+
+  it('returns composite keys as arrays', async () => {
+    await db.Membership.create(new Membership('u1', 'p1'));
+    await db.Membership.create(new Membership('u2', 'p2'));
+
+    const keys = await db.Membership.getKeys();
+    expect(keys).toEqual([
+      ['u1', 'p1'],
+      ['u2', 'p2'],
+    ]);
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,7 @@ export default [
         IDBObjectStoreParameters: 'readonly',
         IDBIndexParameters: 'readonly',
         IDBTransactionMode: 'readonly',
+        IDBValidKey: 'readonly',
       },
     },
     plugins: {

--- a/index.ts
+++ b/index.ts
@@ -1786,6 +1786,15 @@ interface EntityRepository<T> {
   count(): Promise<number>;
 
   /**
+   * Returns the primary keys of all records in the store, without loading
+   * the record values.
+   *
+   * @returns A promise resolving to an array of primary keys, in the
+   *   store's natural key order.
+   */
+  getKeys(): Promise<IDBValidKey[]>;
+
+  /**
    * Returns whether a record with the given primary key exists.
    *
    * @param key - The primary key to check.
@@ -2688,6 +2697,24 @@ class Database {
             return new Promise<number>((resolve, reject) => {
               request.onsuccess = () => {
                 this.printDebug(`Count for ${cls.name}:`, request.result);
+                resolve(request.result);
+              };
+              request.onerror = () => reject(request.error);
+            });
+          },
+          transaction,
+        );
+      },
+
+      getKeys: async (): Promise<IDBValidKey[]> => {
+        return this.performOperation(
+          cls.name,
+          'readonly',
+          (store) => {
+            const request = store.getAllKeys();
+            return new Promise<IDBValidKey[]>((resolve, reject) => {
+              request.onsuccess = () => {
+                this.printDebug(`Keys for ${cls.name}:`, request.result);
                 resolve(request.result);
               };
               request.onerror = () => reject(request.error);


### PR DESCRIPTION
Closes #34

## What
Adds `getKeys(): Promise<IDBValidKey[]>` to every entity repository, returning the primary keys of all records via the native `store.getAllKeys()` — no record values are loaded, making it much cheaper than `list()` when only keys are needed.

## Change (minimal)
- One new method on the `EntityRepository<T>` interface + its implementation (same `performOperation` pattern as `count`/`exists`).
- README utilities example updated.

## Tests
New `__tests__/getkeys.test.ts`: empty store, simple keys, reflects deletions, composite keys returned as arrays. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)