### PR TITLE
fix: fail fast on composite key `generator`/`autoIncrement`

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,13 @@ Designates the decorated property as the primary key of the object store. Exactl
 
 #### `@CompositeKeyPath(fields, options?)`
 
-Class-level decorator for composite primary keys. Cannot be combined with `@KeyPath`.
+Class-level decorator for composite primary keys. Cannot be combined with `@KeyPath`. Write it *below* `@DataClass` (decorators are applied bottom-up, and the key path must be registered before `@DataClass` validates it).
+
+Key generation is not supported for composite keys: passing `generator` or `autoIncrement` throws at decoration time. Provide every key field explicitly before `create()`.
 
 ```typescript
-@CompositeKeyPath(['userId', 'projectId'])
 @DataClass()
+@CompositeKeyPath(['userId', 'projectId'])
 class UserProject {
   userId!: string;
   projectId!: string;
@@ -426,9 +428,11 @@ KeyGenerators.random(); // "xyz789abc"
 
 ### Composite keys
 
+Key generation (`generator` / `autoIncrement`) is not supported for composite keys and throws at decoration time.
+
 ```typescript
-@CompositeKeyPath(['userId', 'projectId'])
 @DataClass()
+@CompositeKeyPath(['userId', 'projectId'])
 class UserProject {
   userId!: string;
   projectId!: string;

--- a/__tests__/composite-key-generator.test.ts
+++ b/__tests__/composite-key-generator.test.ts
@@ -1,0 +1,63 @@
+import { Database, DataClass, CompositeKeyPath } from '../index';
+
+describe('CompositeKeyPath key generation guard', () => {
+  it('throws at decoration time when a generator is configured', () => {
+    expect(() => {
+      class Bad {
+        userId!: string;
+        projectId!: string;
+      }
+      CompositeKeyPath(['userId', 'projectId'], { generator: 'uuid' })(Bad);
+    }).toThrow('Key generators are not supported for composite keys');
+  });
+
+  it('throws at decoration time when a custom generator function is configured', () => {
+    expect(() => {
+      class Bad {
+        userId!: string;
+        projectId!: string;
+      }
+      CompositeKeyPath(['userId', 'projectId'], {
+        generator: () => 'nope',
+      })(Bad);
+    }).toThrow('Key generators are not supported for composite keys');
+  });
+
+  it('throws at decoration time when autoIncrement is configured', () => {
+    expect(() => {
+      class Bad {
+        userId!: string;
+        projectId!: string;
+      }
+      CompositeKeyPath(['userId', 'projectId'], { autoIncrement: true })(Bad);
+    }).toThrow('autoIncrement is not supported for composite keys');
+  });
+
+  it('still accepts composite keys without generation options', async () => {
+    @DataClass()
+    @CompositeKeyPath(['userId', 'projectId'])
+    class Assignment {
+      userId!: string;
+      projectId!: string;
+      role!: string;
+
+      constructor(userId: string, projectId: string, role: string) {
+        this.userId = userId;
+        this.projectId = projectId;
+        this.role = role;
+      }
+    }
+
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('CompositeGuardDB');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    });
+
+    const db: any = await Database.build('CompositeGuardDB', [Assignment]);
+    await db.Assignment.create(new Assignment('u1', 'p1', 'owner'));
+    const stored = await db.Assignment.read(['u1', 'p1']);
+    expect(stored?.role).toBe('owner');
+    db.close();
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -1422,17 +1422,22 @@ function KeyPath(options?: KeyPathOptions): PropertyDecorator {
  * of fields rather than a single property.
  *
  * @param fields  - An ordered array of field names that together form the key.
- * @param options - Optional key generation configuration (note: auto-generated
- *   keys are not supported for composite keys).
+ * @param options - Optional key path configuration. Key generation is **not
+ *   supported** for composite keys: passing `generator` or `autoIncrement`
+ *   throws immediately at decoration time instead of being silently ignored.
  *
  * @remarks
- * Apply `@CompositeKeyPath` **before** `@DataClass` (decorators execute
- * bottom-up). `@KeyPath` must **not** also be used on the same class.
+ * `@CompositeKeyPath` must execute **before** `@DataClass`. Decorators are
+ * applied bottom-up, so write it *below* `@DataClass` (closer to the `class`
+ * keyword). `@KeyPath` must **not** also be used on the same class.
+ *
+ * @throws `Error` - At decoration time when `options.generator` or
+ *   `options.autoIncrement` is provided.
  *
  * @example
  * ```ts
- * @CompositeKeyPath(['userId', 'projectId'])
  * @DataClass()
+ * @CompositeKeyPath(['userId', 'projectId'])
  * class UserProject {
  *   userId!: string;
  *   projectId!: string;
@@ -1448,6 +1453,18 @@ function CompositeKeyPath(
   options?: KeyPathOptions,
 ): ClassDecorator {
   return (target: Function) => {
+    if (options?.generator) {
+      throw new Error(
+        `Key generators are not supported for composite keys on class ${target.name}. ` +
+        'Provide all key fields explicitly before calling create().',
+      );
+    }
+    if (options?.autoIncrement) {
+      throw new Error(
+        `autoIncrement is not supported for composite keys on class ${target.name}.`,
+      );
+    }
+
     const metadata: KeyPathMetadata = {
       fields: fields,
       options: options,


### PR DESCRIPTION
Closes #32

## What
`generateKey` silently returned `undefined` when a `generator` (or `autoIncrement`) was configured on a `@CompositeKeyPath` — the record write then failed later with an opaque IndexedDB key error, or worse, appeared to work while never generating anything.

## Change (minimal)
- `@CompositeKeyPath` now **throws at decoration time** when `options.generator` or `options.autoIncrement` is passed, with a message explaining that composite key fields must be provided explicitly.
- Fixed the decorator-order bug in the docs: both the TSDoc example and two README examples showed `@CompositeKeyPath` *above* `@DataClass`, which actually throws `No keypath field defined` at runtime (decorators apply bottom-up). Examples now show the working order and the README explains why.

## Tests
New `__tests__/composite-key-generator.test.ts`:
- string generator, custom function generator, and `autoIncrement` each throw at decoration time
- a plain composite key entity still round-trips create/read

Existing composite-keys suite still green (19 tests across both suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)