### PR TITLE
fix: `range()` without `useIndex()` now throws instead of being ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,13 @@ When a field is indexed, you can constrain the initial IDB candidate set at the 
 await db.Product.query().useIndex('price').range(10, 100).execute();
 ```
 
+The two mechanisms are deliberately distinct:
+
+- `useIndex(...).range(start, end)` narrows candidates **natively at the IndexedDB layer** via an `IDBKeyRange` — fast, but limited to one indexed field.
+- `.where(...)` conditions are evaluated **in memory** after the candidates are fetched. They can target any field (including one different from the index), at the cost of scanning the fetched candidates.
+
+Mixing them is valid and useful — the index range prunes the bulk, `where()` refines the rest. Calling `range()` **without** `useIndex()` throws at execution time instead of silently ignoring the bounds; express such bounds as `where(field).between(start, end)` instead.
+
 ### Aggregations
 
 ```typescript

--- a/__tests__/range-index.test.ts
+++ b/__tests__/range-index.test.ts
@@ -1,0 +1,69 @@
+import { Database, DataClass, KeyPath, Index } from '../index';
+
+@DataClass()
+class Reading {
+  @KeyPath()
+  id!: string;
+
+  @Index()
+  value!: number;
+
+  sensor!: string;
+
+  constructor(id: string, value: number, sensor: string) {
+    this.id = id;
+    this.value = value;
+    this.sensor = sensor;
+  }
+}
+
+describe('QueryBuilder range()/useIndex() validation', () => {
+  let db: any;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('RangeIndexDB');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    });
+    db = await Database.build('RangeIndexDB', [Reading]);
+    await db.Reading.createMany([
+      new Reading('r1', 10, 'a'),
+      new Reading('r2', 20, 'a'),
+      new Reading('r3', 30, 'b'),
+      new Reading('r4', 40, 'b'),
+    ]);
+  });
+
+  afterAll(() => db.close());
+
+  it('rejects range() without useIndex()', async () => {
+    await expect(db.Reading.query().range(10, 30).execute()).rejects.toThrow(
+      'range() requires useIndex()',
+    );
+  });
+
+  it('rejects a lone lower bound without useIndex()', async () => {
+    await expect(
+      db.Reading.query().range(10, undefined).execute(),
+    ).rejects.toThrow('range() requires useIndex()');
+  });
+
+  it('applies range() through the index when useIndex() is set', async () => {
+    const results = await db.Reading.query()
+      .useIndex('value')
+      .range(15, 35)
+      .execute();
+    expect(results.map((r: Reading) => r.id).sort()).toEqual(['r2', 'r3']);
+  });
+
+  it('still allows where() filters on other fields alongside an index range', async () => {
+    const results = await db.Reading.query()
+      .useIndex('value')
+      .range(15, 45)
+      .where('sensor')
+      .equals('b')
+      .execute();
+    expect(results.map((r: Reading) => r.id).sort()).toEqual(['r3', 'r4']);
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -841,7 +841,13 @@ class QueryBuilder<T> {
 
   /**
    * Constrains the IDB key range used when reading via {@link QueryBuilder.useIndex}.
-   * Has no effect unless `useIndex` has been called.
+   *
+   * Unlike {@link QueryBuilder.where} conditions - which are evaluated
+   * **in memory** after candidates are fetched - the range is applied natively
+   * at the IndexedDB layer, so it narrows the candidate set before any
+   * in-memory filtering runs. Because a range is meaningless without an index
+   * to apply it to, executing a query that sets a range without calling
+   * `useIndex` throws instead of silently ignoring the bounds.
    *
    * @param start - Inclusive lower bound of the key range, or `undefined` for an open lower bound.
    * @param end   - Inclusive upper bound of the key range, or `undefined` for an open upper bound.
@@ -892,6 +898,15 @@ class QueryBuilder<T> {
   /** @internal */
   private createReadRequest(store: IDBObjectStore): IDBRequest {
     if (!this.indexName) {
+      if (this.rangeStart !== undefined || this.rangeEnd !== undefined) {
+        throw new Error(
+          'range() requires useIndex(): key ranges are applied at the ' +
+          'IndexedDB layer through an index. Either call useIndex(indexName) ' +
+          'before range(), or express the bounds as in-memory filters via ' +
+          'where(field).between(start, end) / gte() / lte().',
+        );
+      }
+
       return store.getAll();
     }
 


### PR DESCRIPTION
Closes #31

## What
`range(start, end)` bounds are applied natively via `IDBKeyRange` — but only when `useIndex()` is set. Without an index the bounds were **silently dropped**, so `query().range(10, 100)` returned every record while looking like a filtered query. That's the conflation flagged in the issue: users couldn't tell which constraints run at the IDB layer and which run in memory.

## Change (minimal)
- Executing a query with `range()` set but no `useIndex()` now throws with a message pointing to the two correct alternatives (`useIndex(...)` for native narrowing, `where(field).between(...)` for in-memory filtering).
- TSDoc for `range()` and a new README passage spell out the semantics: index ranges narrow at the IndexedDB layer, `where()` filters in memory, and mixing them is valid (index prunes, `where` refines).

Deliberately **not** an error: `useIndex().range()` combined with `where()` on a different field — that's a legitimate and useful pattern, now documented as such.

## Tests
New `__tests__/range-index.test.ts`:
- `range()` without index rejects (both bounds and single-bound forms)
- `useIndex()+range()` narrows correctly
- index range combined with `where()` on another field still works

Full suite: 14 suites / 101 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)