### PR TITLE
refactor: replace `any` with proper key types in the public API

### DIFF
--- a/__tests__/api-types.compile.ts
+++ b/__tests__/api-types.compile.ts
@@ -1,0 +1,49 @@
+import type { EntityRepository } from '../index';
+import { Database, DataClass, KeyPath, Index } from '../index';
+
+@DataClass()
+class StrictEntity {
+  @KeyPath()
+  id!: string;
+
+  @Index()
+  email!: string;
+
+  age!: number;
+}
+
+async function verifyApiTypes() {
+  const db = await Database.build<{
+    StrictEntity: EntityRepository<StrictEntity>;
+  }>('ApiTypeCheckDB', [StrictEntity]);
+
+  // exists() accepts every primary key shape, matching read()/delete().
+  await db.StrictEntity.exists('simple');
+  await db.StrictEntity.exists(42);
+  await db.StrictEntity.exists(['composite', 'key']);
+
+  // Index lookups accept valid IDB keys.
+  await db.StrictEntity.findByIndex('email', 'a@example.com');
+  await db.StrictEntity.findByIndex('email', 42);
+  await db.StrictEntity.findByIndex('email', new Date());
+  await db.StrictEntity.findOneByIndex('email', ['a', 'b']);
+
+  // Index range bounds are typed as IDB keys.
+  db.StrictEntity.query().useIndex('email').range('a', 'z');
+  db.StrictEntity.query().useIndex('email').range(1, 99);
+  db.StrictEntity.query().useIndex('email').range(undefined, 'z');
+
+  // @ts-expect-error booleans are not valid IndexedDB keys
+  await db.StrictEntity.findByIndex('email', true);
+
+  // @ts-expect-error objects are not valid IndexedDB keys
+  await db.StrictEntity.findOneByIndex('email', { nested: true });
+
+  // @ts-expect-error booleans are not valid IndexedDB range bounds
+  db.StrictEntity.query().useIndex('email').range(true, false);
+
+  // @ts-expect-error null is not a valid exists() key
+  await db.StrictEntity.exists(null);
+}
+
+void verifyApiTypes();

--- a/__tests__/api-types.test.ts
+++ b/__tests__/api-types.test.ts
@@ -1,0 +1,52 @@
+import { Database, DataClass, KeyPath, CompositeKeyPath } from '../index';
+
+@DataClass()
+class NumericKeyed {
+  @KeyPath({ autoIncrement: true })
+  id!: number;
+
+  label!: string;
+
+  constructor(label: string) {
+    this.label = label;
+  }
+}
+
+@DataClass()
+@CompositeKeyPath(['region', 'code'])
+class Locale {
+  region!: string;
+  code!: string;
+
+  constructor(region: string, code: string) {
+    this.region = region;
+    this.code = code;
+  }
+}
+
+describe('exists() accepts every primary key shape', () => {
+  let db: any;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('ApiTypesDB');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    });
+    db = await Database.build('ApiTypesDB', [NumericKeyed, Locale]);
+  });
+
+  afterAll(() => db.close());
+
+  it('checks numeric auto-increment keys', async () => {
+    await db.NumericKeyed.create(new NumericKeyed('first'));
+    expect(await db.NumericKeyed.exists(1)).toBe(true);
+    expect(await db.NumericKeyed.exists(999)).toBe(false);
+  });
+
+  it('checks composite keys passed as arrays', async () => {
+    await db.Locale.create(new Locale('eu', 'de-DE'));
+    expect(await db.Locale.exists(['eu', 'de-DE'])).toBe(true);
+    expect(await db.Locale.exists(['eu', 'fr-FR'])).toBe(false);
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,7 @@ export default [
         IDBObjectStoreParameters: 'readonly',
         IDBIndexParameters: 'readonly',
         IDBTransactionMode: 'readonly',
+        IDBValidKey: 'readonly',
       },
     },
     plugins: {

--- a/index.ts
+++ b/index.ts
@@ -505,8 +505,8 @@ class QueryBuilder<T> {
   private limitCount?: number;
   private offsetCount?: number;
   private indexName?: string;
-  private rangeStart?: any;
-  private rangeEnd?: any;
+  private rangeStart?: IDBValidKey;
+  private rangeEnd?: IDBValidKey;
   private currentField?: string;
   private groupField?: Extract<keyof T, string>;
   private pendingConnector: QueryConnector = 'and';
@@ -847,7 +847,7 @@ class QueryBuilder<T> {
    * @param end   - Inclusive upper bound of the key range, or `undefined` for an open upper bound.
    * @returns `this` for chaining.
    */
-  range(start: any, end: any) {
+  range(start: IDBValidKey | undefined, end: IDBValidKey | undefined) {
     this.rangeStart = start;
     this.rangeEnd = end;
     return this;
@@ -1763,20 +1763,25 @@ interface EntityRepository<T> {
    * Returns all records whose indexed field equals `value`.
    *
    * @param indexName - The name of the IDB index to query.
-   * @param value     - The index key to look up.
+   * @param value     - The index key to look up. Must be a valid IndexedDB
+   *   key (`string`, `number`, `Date`, `ArrayBuffer` view, or an array of
+   *   those); booleans and plain objects are rejected at compile time.
    * @throws `Error` if the named index does not exist.
    */
-  findByIndex(indexName: string, value: any): Promise<T[]>;
+  findByIndex(indexName: string, value: IDBValidKey): Promise<T[]>;
 
   /**
    * Returns the first record whose indexed field equals `value`, or
    * `undefined` if none is found.
    *
    * @param indexName - The name of the IDB index to query.
-   * @param value     - The index key to look up.
+   * @param value     - The index key to look up. Must be a valid IndexedDB key.
    * @throws `Error` if the named index does not exist.
    */
-  findOneByIndex(indexName: string, value: any): Promise<T | undefined>;
+  findOneByIndex(
+    indexName: string,
+    value: IDBValidKey,
+  ): Promise<T | undefined>;
 
   /**
    * Returns the total number of records in the store.
@@ -1788,10 +1793,12 @@ interface EntityRepository<T> {
   /**
    * Returns whether a record with the given primary key exists.
    *
-   * @param key - The primary key to check.
+   * @param key - The primary key to check. Accepts the same key shapes as
+   *   {@link EntityRepository.read}: a string, a number, or an array for
+   *   composite keys.
    * @returns `true` if a matching record exists, `false` otherwise.
    */
-  exists(key: string): Promise<boolean>;
+  exists(key: string | string[] | number): Promise<boolean>;
 
   /**
    * Deletes **all** records from the store.
@@ -2620,7 +2627,10 @@ class Database {
         );
       },
 
-      findByIndex: async (indexName: string, value: any): Promise<T[]> => {
+      findByIndex: async (
+        indexName: string,
+        value: IDBValidKey,
+      ): Promise<T[]> => {
         return this.performOperation(
           cls.name,
           'readonly',
@@ -2650,7 +2660,7 @@ class Database {
 
       findOneByIndex: async (
         indexName: string,
-        value: any,
+        value: IDBValidKey,
       ): Promise<T | undefined> => {
         return this.performOperation(
           cls.name,
@@ -2697,7 +2707,7 @@ class Database {
         );
       },
 
-      exists: async (key: string): Promise<boolean> => {
+      exists: async (key: string | string[] | number): Promise<boolean> => {
         return this.performOperation(
           cls.name,
           'readonly',


### PR DESCRIPTION
Closes #30

## What
Tightens the loosest `any` surfaces in the public API, focusing on places where the type system can catch real bugs (invalid IndexedDB keys) without breaking legitimate callers:

| API | Before | After |
| --- | --- | --- |
| `findByIndex(indexName, value)` | `value: any` | `value: IDBValidKey` |
| `findOneByIndex(indexName, value)` | `value: any` | `value: IDBValidKey` |
| `exists(key)` | `key: string` (rejected valid numeric/composite keys!) | `key: string \| string[] \| number` (same shapes as `read`/`delete`) |
| `QueryBuilder.range(start, end)` | `any, any` | `IDBValidKey \| undefined` |
| `rangeStart`/`rangeEnd` fields | `any` | `IDBValidKey` |

Booleans and plain objects — never valid IndexedDB keys, previously accepted and failing at runtime — are now compile-time errors. `exists()` was also *too narrow* before: composite and auto-increment keys couldn't be checked without a cast.

Also adds `IDBValidKey` to the eslint TS globals, following the existing pattern for `IDBObjectStoreParameters` etc.

Scope note: internal `any`s (clause evaluation, aggregation plumbing) are left alone deliberately — changing them ripples through comparison operators with no user-facing benefit, violating the minimal-modification constraint.

## Tests
- `__tests__/api-types.compile.ts` — compile-time assertions (enforced by `pnpm test:types`): valid key shapes accepted, `@ts-expect-error` on booleans/objects/null.
- `__tests__/api-types.test.ts` — runtime proof that the widened `exists()` works with numeric auto-increment keys and composite key arrays.

Full suite: 14 suites / 99 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)