### PR TITLE
feat: `@Calculated` decorator for computed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ Creates an IDB index on the decorated field, enabling efficient lookups via `fin
 
 Attaches a validation rule to the decorated property. Rules are enforced on every `create` and `update` call. If any rule fails, the operation throws with a message listing all failing fields.
 
+#### `@Calculated(compute)`
+
+Derives the decorated property from the rest of the entity on every `create` and `update`. See [Calculated Fields](#calculated-fields).
+
 #### `@RetentionPolicy(options)`
 
 Class-level decorator that configures automatic expiry and deletion of records. See [Data Retention](#data-retention) for full details.
@@ -478,6 +482,38 @@ Error format on failure:
 ```
 Validation failed for User: email: must be a valid email address; age: must be a non-negative integer
 ```
+
+---
+
+## Calculated Fields
+
+`@Calculated` derives a property from the rest of the entity on every write. The compute function runs on `create` and `update`, **before** validation and timestamps:
+
+```typescript
+import { Calculated } from 'idb-ts';
+
+@DataClass()
+class OrderLine {
+  @KeyPath({ generator: 'uuid' })
+  id!: string;
+
+  quantity!: number;
+  unitPrice!: number;
+
+  @Calculated<OrderLine>((line) => line.quantity * line.unitPrice)
+  total!: number;
+}
+
+await db.OrderLine.create({ id: '', quantity: 3, unitPrice: 9.5 } as OrderLine);
+(await db.OrderLine.read(id))!.total; // 28.5 - computed and persisted
+```
+
+Semantics:
+
+- Any value the caller assigns to a calculated field is **overwritten** by the compute function on write.
+- `@Validate` rules on the same field see the computed value.
+- The value is persisted, so it can be indexed with `@Index` and queried like any ordinary field.
+- It reflects entity state as of the **last write** - update the inputs and the field recomputes on the next `update`.
 
 ---
 

--- a/__tests__/calculated.test.ts
+++ b/__tests__/calculated.test.ts
@@ -1,0 +1,81 @@
+import { Database, DataClass, KeyPath, Calculated, Validate } from '../index';
+
+@DataClass()
+class OrderLine {
+  @KeyPath()
+  id!: string;
+
+  quantity!: number;
+  unitPrice!: number;
+
+  @Calculated<OrderLine>((item) => item.quantity * item.unitPrice)
+  total!: number;
+
+  constructor(id: string, quantity: number, unitPrice: number) {
+    this.id = id;
+    this.quantity = quantity;
+    this.unitPrice = unitPrice;
+  }
+}
+
+@DataClass()
+class Profile {
+  @KeyPath()
+  id!: string;
+
+  firstName!: string;
+  lastName!: string;
+
+  @Calculated<Profile>((item) => `${item.firstName} ${item.lastName}`)
+  @Validate((v) => typeof v === 'string' && v.trim().length > 1, 'full name required')
+  fullName!: string;
+
+  constructor(id: string, firstName: string, lastName: string) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+}
+
+describe('@Calculated fields', () => {
+  let db: any;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('CalculatedDB');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    });
+    db = await Database.build('CalculatedDB', [OrderLine, Profile]);
+  });
+
+  afterAll(() => db.close());
+
+  it('computes the field on create', async () => {
+    await db.OrderLine.create(new OrderLine('o1', 3, 9.5));
+    const stored = await db.OrderLine.read('o1');
+    expect(stored?.total).toBe(28.5);
+  });
+
+  it('recomputes the field on update', async () => {
+    const stored = await db.OrderLine.read('o1');
+    stored.quantity = 4;
+    stored.total = -1; // stale value must be overwritten
+    await db.OrderLine.update(stored);
+
+    const updated = await db.OrderLine.read('o1');
+    expect(updated?.total).toBe(38);
+  });
+
+  it('is queryable like any persisted field', async () => {
+    await db.OrderLine.create(new OrderLine('o2', 1, 100));
+    const results = await db.OrderLine.query().where('total').gt(50).execute();
+    expect(results.map((line: OrderLine) => line.id)).toEqual(['o2']);
+  });
+
+  it('runs before validation so validators see the computed value', async () => {
+    await db.Profile.create(new Profile('u1', 'Ada', 'Lovelace'));
+    const profile = await db.Profile.read('u1');
+    expect(profile?.fullName).toBe('Ada Lovelace');
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -1536,6 +1536,65 @@ function Validate<T = any>(
 }
 
 /**
+ * Describes a calculated field registered via {@link Calculated}.
+ *
+ * @typeParam T - The entity type the field belongs to.
+ * @internal
+ */
+interface CalculatedFieldMetadata<T = any> {
+  /** Name of the field that receives the computed value. */
+  field: string;
+  /** Derives the field value from the rest of the entity. */
+  compute: (item: T) => any;
+}
+
+/**
+ * Property decorator that derives the decorated field's value from the rest
+ * of the entity on every write.
+ *
+ * The compute function runs on each {@link EntityRepository.create} and
+ * {@link EntityRepository.update} **before** validation and timestamps, so:
+ *
+ * - any value assigned to the field by the caller is overwritten,
+ * - `@Validate` rules on the same field see the computed value,
+ * - the computed value is persisted and therefore works with indexes and
+ *   the query builder like any ordinary field.
+ *
+ * Because the value is computed at write time, it reflects the entity state
+ * as of the last write - change an input field and the calculated field
+ * refreshes on the next `update`.
+ *
+ * @typeParam T - The entity class the field belongs to.
+ * @param compute - Function deriving the field value from the entity.
+ *
+ * @example
+ * ```ts
+ * @DataClass()
+ * class OrderLine {
+ *   @KeyPath({ generator: 'uuid' })
+ *   id!: string;
+ *
+ *   quantity!: number;
+ *   unitPrice!: number;
+ *
+ *   @Calculated<OrderLine>((line) => line.quantity * line.unitPrice)
+ *   total!: number;
+ * }
+ * ```
+ */
+function Calculated<T = any>(compute: (item: T) => any): PropertyDecorator {
+  return (target: Object, propertyKey: string | symbol) => {
+    const constructor = target.constructor as Function;
+    const existing = Reflect.getMetadata('calculated', constructor) || [];
+    const nextFields = [
+      ...existing,
+      { field: propertyKey as string, compute } as CalculatedFieldMetadata<T>,
+    ];
+    Reflect.defineMetadata('calculated', nextFields, constructor);
+  };
+}
+
+/**
  * Class decorator that configures an automatic data retention policy for
  * the entity. When one or more entities define a retention policy, the
  * {@link Database} runs a background cleanup job that periodically deletes
@@ -2295,6 +2354,14 @@ class Database {
     const updateTimestampField = INTERNAL_UPDATED_AT_FIELD;
     const validators = (Reflect.getMetadata('validators', cls) ||
       []) as ValidationRule<T>[];
+    const calculatedFields = (Reflect.getMetadata('calculated', cls) ||
+      []) as CalculatedFieldMetadata<T>[];
+
+    const applyCalculatedFields = (item: T): void => {
+      calculatedFields.forEach(({ field, compute }) => {
+        (item as any)[field] = compute(item);
+      });
+    };
 
     const validateItem = (item: T): void => {
       const failures: string[] = [];
@@ -2475,6 +2542,7 @@ class Database {
           }
         }
 
+        applyCalculatedFields(item);
         validateItem(item);
         applyTimestampFields(item);
 
@@ -2516,6 +2584,7 @@ class Database {
       },
 
       update: async (item: T): Promise<void> => {
+        applyCalculatedFields(item);
         validateItem(item);
 
         return this.performOperation(
@@ -2992,6 +3061,7 @@ export {
   DataClass,
   Index,
   Validate,
+  Calculated,
   RetentionPolicy,
   EntityRepository,
   KeyGenerators,


### PR DESCRIPTION
Closes #37

## What
New `@Calculated(compute)` property decorator: derives a field from the rest of the entity on every write.

```ts
@Calculated<OrderLine>((line) => line.quantity * line.unitPrice)
total!: number;
```

## Design
Computed **at write time** (create/update), before validation and timestamps. That single choice buys a lot for free:
- the value is persisted, so indexes and the query builder treat it like any ordinary field — no changes needed anywhere in the read/query paths,
- `@Validate` rules on the same field see the computed value,
- caller-assigned values are deterministically overwritten (no stale-value ambiguity).

The trade-off (documented in README + TSDoc): the value reflects entity state as of the last write. Read-time recomputation was rejected — it would require hooking every read path (`read`, `list`, `findByIndex`, query execution, …) and would break indexing on computed values.

Implementation follows the exact metadata pattern of `@Validate`: a `'calculated'` reflect-metadata list, applied by a small `applyCalculatedFields` helper in the two write paths. ~40 lines of code + docs.

## Tests
New `__tests__/calculated.test.ts`:
- computed on create; recomputed on update (stale caller value overwritten)
- queryable via the query builder
- validators see the computed value

Full suite: 14 suites / 101 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)