### PR TITLE
feat: `exportDatabase()` / `importDatabase()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,28 @@ await db.User.deleteMany(['u1', 'u2', 'u3']);
 
 ---
 
+## Export / Import
+
+Snapshot every registered store to a plain serialisable object, and load such a snapshot back - useful for backups, test fixtures, and moving data between environments.
+
+```typescript
+// Export: { EntityName: records[] } for every registered entity
+const dump = await db.exportDatabase();
+localStorage.setItem('backup', JSON.stringify(dump));
+
+// Import: writes records verbatim (timestamps preserved), upserting by key
+await db.importDatabase(JSON.parse(localStorage.getItem('backup')!));
+
+// Replace instead of merge
+await db.importDatabase(dump, { clear: true });
+```
+
+- Records are written with `put`, so importing over existing keys overwrites those records; other records are kept unless `clear: true` is passed.
+- Dump entries whose entity is not registered in this database are skipped.
+- Internal `__idb_createdAt` / `__idb_updatedAt` fields survive the round-trip verbatim; validation and key generation are bypassed so the restored data matches the exported data exactly.
+
+---
+
 ## Performance
 
 <!-- performance start -->

--- a/__tests__/export-import.test.ts
+++ b/__tests__/export-import.test.ts
@@ -1,0 +1,108 @@
+import { Database, DataClass, KeyPath, Index } from '../index';
+
+@DataClass()
+class Author {
+  @KeyPath()
+  id!: string;
+
+  @Index()
+  name!: string;
+
+  constructor(id: string, name: string) {
+    this.id = id;
+    this.name = name;
+  }
+}
+
+@DataClass()
+class Book {
+  @KeyPath()
+  isbn!: string;
+
+  title!: string;
+  authorId!: string;
+
+  constructor(isbn: string, title: string, authorId: string) {
+    this.isbn = isbn;
+    this.title = title;
+    this.authorId = authorId;
+  }
+}
+
+const destroy = (name: string): Promise<void> =>
+  new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+  });
+
+describe('Database export/import', () => {
+  let db: any;
+
+  beforeAll(async () => {
+    await destroy('ExportSourceDB');
+    await destroy('ImportTargetDB');
+    db = await Database.build('ExportSourceDB', [Author, Book]);
+    await db.Author.create(new Author('a1', 'Ursula K. Le Guin'));
+    await db.Book.create(new Book('978-0', 'A Wizard of Earthsea', 'a1'));
+    await db.Book.create(new Book('978-1', 'The Dispossessed', 'a1'));
+  });
+
+  afterAll(() => db.close());
+
+  it('exports every registered store keyed by entity name', async () => {
+    const dump = await db.exportDatabase();
+
+    expect(Object.keys(dump).sort()).toEqual(['Author', 'Book']);
+    expect(dump.Author).toHaveLength(1);
+    expect(dump.Book).toHaveLength(2);
+    expect(dump.Author[0].name).toBe('Ursula K. Le Guin');
+    // Internal timestamps are part of the record and survive the export.
+    expect(typeof dump.Author[0].__idb_createdAt).toBe('number');
+  });
+
+  it('imports a dump into another database preserving records verbatim', async () => {
+    const dump = await db.exportDatabase();
+
+    const target: any = await Database.build('ImportTargetDB', [Author, Book]);
+    await target.importDatabase(dump);
+
+    expect(await target.Book.count()).toBe(2);
+    const author = await target.Author.read('a1');
+    expect(author?.name).toBe('Ursula K. Le Guin');
+    // Timestamps are preserved verbatim, not regenerated.
+    expect(author?.__idb_createdAt).toBe(dump.Author[0].__idb_createdAt);
+    target.close();
+  });
+
+  it('import with clear replaces existing data', async () => {
+    const target: any = await Database.build('ImportTargetDB', [Author, Book]);
+    await target.Book.create(new Book('999-9', 'Stale record', 'a1'));
+
+    const dump = await db.exportDatabase();
+    await target.importDatabase(dump, { clear: true });
+
+    expect(await target.Book.count()).toBe(2);
+    expect(await target.Book.read('999-9')).toBeUndefined();
+    target.close();
+  });
+
+  it('import without clear upserts into existing data', async () => {
+    const target: any = await Database.build('ImportTargetDB', [Author, Book]);
+    await target.Book.create(new Book('999-8', 'Kept record', 'a1'));
+
+    await target.importDatabase(await db.exportDatabase());
+
+    expect(await target.Book.count()).toBe(3);
+    expect((await target.Book.read('999-8'))?.title).toBe('Kept record');
+    target.close();
+  });
+
+  it('ignores dump entries for unregistered entities', async () => {
+    const target: any = await Database.build('ImportTargetDB', [Author, Book]);
+    await expect(
+      target.importDatabase({ Ghost: [{ id: 'g1' }] }),
+    ).resolves.toBeUndefined();
+    target.close();
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -2918,6 +2918,114 @@ class Database {
   }
 
   /**
+   * Exports every registered entity store as a plain, JSON-serialisable
+   * object keyed by entity class name.
+   *
+   * Records are exported verbatim, including the internal
+   * `__idb_createdAt` / `__idb_updatedAt` timestamp fields, so a subsequent
+   * {@link Database.importDatabase} restores them exactly.
+   *
+   * @returns A promise resolving to `{ EntityName: records[] }`.
+   *
+   * @example
+   * ```ts
+   * const dump = await db.exportDatabase();
+   * localStorage.setItem('backup', JSON.stringify(dump));
+   * ```
+   */
+  async exportDatabase(): Promise<Record<string, unknown[]>> {
+    const dump: Record<string, unknown[]> = {};
+
+    for (const cls of this.classes) {
+      const repository = this.entityRepositories.get(cls.name) as
+        | EntityRepository<unknown>
+        | undefined;
+      if (repository) {
+        dump[cls.name] = await repository.list();
+      }
+    }
+
+    return dump;
+  }
+
+  /**
+   * Imports a dump produced by {@link Database.exportDatabase}.
+   *
+   * Records are written verbatim with `put` semantics: records whose primary
+   * key already exists are overwritten, all others are inserted. Existing
+   * records not present in the dump are kept unless `options.clear` is set.
+   * Validation, key generation, and timestamp injection are intentionally
+   * bypassed so the imported data matches the exported data exactly.
+   *
+   * Dump entries whose entity name is not registered in this database are
+   * skipped (a debug message is logged).
+   *
+   * @param dump    - `{ EntityName: records[] }` as returned by `exportDatabase`.
+   * @param options - Set `clear: true` to empty each store before importing.
+   *
+   * @example
+   * ```ts
+   * await db.importDatabase(JSON.parse(backupJson));
+   * await db.importDatabase(dump, { clear: true }); // replace instead of merge
+   * ```
+   */
+  async importDatabase(
+    dump: Record<string, unknown[]>,
+    options: { clear?: boolean } = {},
+  ): Promise<void> {
+    for (const [entityName, records] of Object.entries(dump)) {
+      const entityClass = this.classes.find((cls) => cls.name === entityName);
+      if (!entityClass) {
+        this.printDebug(
+          `Skipping import for unregistered entity '${entityName}'.`,
+        );
+        continue;
+      }
+
+      if (!Array.isArray(records)) {
+        this.printDebug(
+          `Skipping import for '${entityName}': expected an array of records.`,
+        );
+        continue;
+      }
+
+      await this.performOperation(entityName, 'readwrite', (store) => {
+        return new Promise<void>((resolve, reject) => {
+          const writeRecords = () => {
+            let pending = records.length;
+            if (!pending) {
+              resolve();
+              return;
+            }
+
+            records.forEach((record) => {
+              const request = store.put(record);
+              request.onsuccess = () => {
+                pending -= 1;
+                if (!pending) resolve();
+              };
+              request.onerror = () => reject(request.error);
+            });
+          };
+
+          if (options.clear) {
+            const clearRequest = store.clear();
+            clearRequest.onsuccess = () => writeRecords();
+            clearRequest.onerror = () => reject(clearRequest.error);
+            return;
+          }
+
+          writeRecords();
+        });
+      });
+
+      this.printDebug(
+        `Imported ${records.length} record(s) into '${entityName}'.`,
+      );
+    }
+  }
+
+  /**
    * Closes the underlying IDB connection and stops the retention cleanup timer.
    * The instance must not be used after calling this method.
    *


### PR DESCRIPTION
Closes #23

## What
Two `Database` methods for whole-database snapshots:

- `exportDatabase(): Promise<Record<string, unknown[]>>` — `{ EntityName: records[] }` for every registered entity, JSON-serialisable.
- `importDatabase(dump, { clear? })` — writes records back verbatim with `put` semantics (upsert by key). `clear: true` replaces store contents instead of merging.

Useful for backups, test fixtures, and moving data between environments — and it provides the data-shovelling primitive for #20 (sync adapters), as the issue notes.

## Design decisions
- **Verbatim restore**: validation, key generation, and timestamp injection are bypassed on import so restored data is byte-for-byte what was exported (internal `__idb_createdAt`/`__idb_updatedAt` included). An import that re-validated could reject data the same app previously wrote.
- Dump entries for unregistered entities are **skipped** (debug-logged), so a backup from a newer app version doesn't explode an older one.

## Tests
New `__tests__/export-import.test.ts` (5 tests): export shape, cross-database round-trip with timestamp preservation, `clear` replace, merge/upsert without `clear`, unregistered-entity skip.

Full suite: 14 suites / 102 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)