### PR TITLE
feat: `SyncAdapter` interface + `pushTo`/`pullFrom`

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,38 @@ await db.User.deleteMany(['u1', 'u2', 'u3']);
 
 ---
 
+## Sync Adapters (experimental)
+
+Bridge the local IndexedDB with any backend by implementing the two-method `SyncAdapter` interface. The library stays transport-agnostic - REST, WebSocket, or in-memory adapters all work the same way.
+
+```typescript
+import type { SyncAdapter } from 'idb-ts';
+
+class RestAdapter implements SyncAdapter {
+  async push(entityName: string, records: unknown[]): Promise<void> {
+    await fetch(`/api/sync/${entityName}`, {
+      method: 'PUT',
+      body: JSON.stringify(records),
+    });
+  }
+
+  async pull(entityName: string): Promise<unknown[] | undefined> {
+    const response = await fetch(`/api/sync/${entityName}`);
+    return response.ok ? response.json() : undefined;
+  }
+}
+
+const adapter = new RestAdapter();
+await db.pushTo(adapter); // sends every entity's records to the adapter
+await db.pullFrom(adapter); // upserts records returned by the adapter
+```
+
+- `pushTo` calls `adapter.push(entityName, records)` once per registered entity.
+- `pullFrom` calls `adapter.pull(entityName)` per entity and upserts the returned records by primary key; returning `undefined` leaves that store untouched.
+- Conflict resolution is intentionally left to the adapter/backend - locally, pulled records win by primary key.
+
+---
+
 ## Performance
 
 <!-- performance start -->

--- a/__tests__/sync-adapter.test.ts
+++ b/__tests__/sync-adapter.test.ts
@@ -1,0 +1,103 @@
+import { Database, DataClass, KeyPath } from '../index';
+import type { SyncAdapter } from '../index';
+
+@DataClass()
+class Contact {
+  @KeyPath()
+  id!: string;
+
+  name!: string;
+
+  constructor(id: string, name: string) {
+    this.id = id;
+    this.name = name;
+  }
+}
+
+/** Minimal in-memory adapter standing in for a real backend. */
+class MemoryAdapter implements SyncAdapter {
+  store = new Map<string, unknown[]>();
+
+  async push(entityName: string, records: unknown[]): Promise<void> {
+    this.store.set(entityName, records);
+  }
+
+  async pull(entityName: string): Promise<unknown[] | undefined> {
+    return this.store.get(entityName);
+  }
+}
+
+const destroy = (name: string): Promise<void> =>
+  new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+  });
+
+describe('SyncAdapter push/pull', () => {
+  beforeAll(async () => {
+    await destroy('SyncSourceDB');
+    await destroy('SyncTargetDB');
+  });
+
+  it('pushTo hands every entity store to the adapter', async () => {
+    const db: any = await Database.build('SyncSourceDB', [Contact]);
+    await db.Contact.create(new Contact('c1', 'Alice'));
+    await db.Contact.create(new Contact('c2', 'Bob'));
+
+    const adapter = new MemoryAdapter();
+    await db.pushTo(adapter);
+
+    expect(adapter.store.get('Contact')).toHaveLength(2);
+    db.close();
+  });
+
+  it('pullFrom applies adapter records into the local database', async () => {
+    const adapter = new MemoryAdapter();
+    adapter.store.set('Contact', [
+      { id: 'c9', name: 'Remote Rita' },
+      { id: 'c10', name: 'Remote Rob' },
+    ]);
+
+    const db: any = await Database.build('SyncTargetDB', [Contact]);
+    await db.pullFrom(adapter);
+
+    expect(await db.Contact.count()).toBe(2);
+    expect((await db.Contact.read('c9'))?.name).toBe('Remote Rita');
+    db.close();
+  });
+
+  it('pullFrom upserts over existing records and skips absent entities', async () => {
+    const db: any = await Database.build('SyncTargetDB', [Contact]);
+
+    const adapter = new MemoryAdapter();
+    adapter.store.set('Contact', [{ id: 'c9', name: 'Renamed Rita' }]);
+    await db.pullFrom(adapter);
+
+    expect((await db.Contact.read('c9'))?.name).toBe('Renamed Rita');
+    // c10 remains from the previous pull - pull merges, it does not wipe.
+    expect(await db.Contact.count()).toBe(2);
+
+    // An adapter returning undefined for an entity leaves the store alone.
+    const emptyAdapter = new MemoryAdapter();
+    await db.pullFrom(emptyAdapter);
+    expect(await db.Contact.count()).toBe(2);
+    db.close();
+  });
+
+  it('round-trips between two databases through the adapter', async () => {
+    const adapter = new MemoryAdapter();
+
+    const source: any = await Database.build('SyncSourceDB', [Contact]);
+    await source.pushTo(adapter);
+    source.close();
+
+    await destroy('SyncRoundTripDB');
+    const replica: any = await Database.build('SyncRoundTripDB', [Contact]);
+    await replica.pullFrom(adapter);
+
+    expect(await replica.Contact.count()).toBe(2);
+    expect((await replica.Contact.read('c1'))?.name).toBe('Alice');
+    replica.close();
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -1860,6 +1860,52 @@ type TransactionalDatabase<T extends Record<string, EntityRepository<any>>> =
  */
 type DatabaseWithRepositories<T extends Record<string, any>> = Database & T;
 
+/**
+ * Transport-agnostic adapter bridging the local IndexedDB with any backend.
+ *
+ * Implement these two methods over your transport of choice (REST,
+ * WebSocket, in-memory, ...) and pass the adapter to
+ * {@link Database.pushTo} / {@link Database.pullFrom}. The library never
+ * assumes anything about the transport; conflict resolution is left to the
+ * adapter/backend (locally, pulled records win by primary key).
+ *
+ * @example
+ * ```ts
+ * class RestAdapter implements SyncAdapter {
+ *   async push(entityName: string, records: unknown[]): Promise<void> {
+ *     await fetch(`/api/sync/${entityName}`, {
+ *       method: 'PUT',
+ *       body: JSON.stringify(records),
+ *     });
+ *   }
+ *
+ *   async pull(entityName: string): Promise<unknown[] | undefined> {
+ *     const response = await fetch(`/api/sync/${entityName}`);
+ *     return response.ok ? response.json() : undefined;
+ *   }
+ * }
+ * ```
+ */
+interface SyncAdapter {
+  /**
+   * Receives the full record list of one entity store during
+   * {@link Database.pushTo}.
+   *
+   * @param entityName - The entity class name, e.g. `"User"`.
+   * @param records    - All records currently in that entity's store.
+   */
+  push(entityName: string, records: unknown[]): Promise<void>;
+
+  /**
+   * Supplies records for one entity store during {@link Database.pullFrom}.
+   *
+   * @param entityName - The entity class name, e.g. `"User"`.
+   * @returns The records to upsert locally, or `undefined` to leave the
+   *   local store untouched.
+   */
+  pull(entityName: string): Promise<unknown[] | undefined>;
+}
+
 // ─── Database ────────────────────────────────────────────────────────────────
 
 /**
@@ -2918,6 +2964,93 @@ class Database {
   }
 
   /**
+   * Pushes the full contents of every registered entity store to the given
+   * {@link SyncAdapter}, one `adapter.push(entityName, records)` call per
+   * entity.
+   *
+   * @param adapter - The sync adapter receiving the records.
+   *
+   * @example
+   * ```ts
+   * await db.pushTo(new RestAdapter());
+   * ```
+   */
+  async pushTo(adapter: SyncAdapter): Promise<void> {
+    for (const cls of this.classes) {
+      const repository = this.entityRepositories.get(cls.name) as
+        | EntityRepository<unknown>
+        | undefined;
+      if (!repository) {
+        continue;
+      }
+
+      const records = await repository.list();
+      await adapter.push(cls.name, records);
+      this.printDebug(
+        `Pushed ${records.length} record(s) of '${cls.name}' to adapter.`,
+      );
+    }
+  }
+
+  /**
+   * Pulls records from the given {@link SyncAdapter} and upserts them into
+   * the local stores by primary key.
+   *
+   * For each registered entity, `adapter.pull(entityName)` is called once.
+   * Returned records are written verbatim with `put` semantics (existing
+   * keys are overwritten, other local records are kept). When the adapter
+   * returns `undefined` for an entity, its local store is left untouched.
+   *
+   * Conflict resolution is intentionally delegated to the adapter/backend -
+   * locally, pulled records win by primary key.
+   *
+   * @param adapter - The sync adapter supplying the records.
+   *
+   * @example
+   * ```ts
+   * await db.pullFrom(new RestAdapter());
+   * ```
+   */
+  async pullFrom(adapter: SyncAdapter): Promise<void> {
+    for (const cls of this.classes) {
+      const records = await adapter.pull(cls.name);
+      if (records === undefined) {
+        continue;
+      }
+
+      if (!Array.isArray(records)) {
+        this.printDebug(
+          `Skipping pull for '${cls.name}': adapter did not return an array.`,
+        );
+        continue;
+      }
+
+      await this.performOperation(cls.name, 'readwrite', (store) => {
+        return new Promise<void>((resolve, reject) => {
+          let pending = records.length;
+          if (!pending) {
+            resolve();
+            return;
+          }
+
+          records.forEach((record) => {
+            const request = store.put(record);
+            request.onsuccess = () => {
+              pending -= 1;
+              if (!pending) resolve();
+            };
+            request.onerror = () => reject(request.error);
+          });
+        });
+      });
+
+      this.printDebug(
+        `Pulled ${records.length} record(s) of '${cls.name}' from adapter.`,
+      );
+    }
+  }
+
+  /**
    * Closes the underlying IDB connection and stops the retention cleanup timer.
    * The instance must not be used after calling this method.
    *
@@ -3003,4 +3136,5 @@ export type {
   KeyPathMetadata,
   RetentionPolicyOptions,
   RetentionPolicyMetadata,
+  SyncAdapter,
 };


### PR DESCRIPTION
Closes #20

## What
A minimal, transport-agnostic sync foundation — "provide different adapters" as the issue asks, without coupling the library to any backend:

```ts
interface SyncAdapter {
  push(entityName: string, records: unknown[]): Promise<void>;
  pull(entityName: string): Promise<unknown[] | undefined>;
}
```

- `db.pushTo(adapter)` — hands every registered entity's full record list to the adapter.
- `db.pullFrom(adapter)` — upserts adapter-supplied records by primary key; an adapter returning `undefined` for an entity leaves that store untouched.

Any transport becomes an adapter in ~10 lines (README shows a REST example; the tests use an in-memory one).

## Design decisions
- **Two primitives, no policy**: conflict resolution, deltas, and scheduling belong to the adapter/backend. Locally the rule is simple and documented — pulled records win by primary key, nothing else is deleted.
- Records transfer verbatim (timestamps included), same rationale as the export/import PR (#47): a sync that re-validated or re-keyed could corrupt round-trips.
- Marked **experimental** in the README so the surface can evolve (deltas, tombstones) without a breaking-change fight.

## Tests
New `__tests__/sync-adapter.test.ts` (4 tests, in-memory adapter): push hands over all stores, pull applies records, pull upserts/merges and skips `undefined` entities, and a full DB→adapter→DB round-trip.

Full suite: 14 suites / 101 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)